### PR TITLE
Tune up templates and implement subscription

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+Upcoming
+------
+
+* Implement the ability to subscribe to discussions.
+* Add back links to multiple templates.
+
 v0.1.1
 ------
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@ Upcoming
 
 * Implement the ability to subscribe to discussions.
 * Add back links to multiple templates.
+* De-require `django` again (to test this locally, you'll need to install it manually).
 
 v0.1.1
 ------

--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,11 @@
-#v0.1
+v0.1.1
+------
+
+* Fix a deployment bug by adding `MANIFEST.in`.
+* Add a missing requirement for `django`.
+
+v0.1
+----
+
+Initial release.
 

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -51,12 +51,15 @@ class DiscussionSubscribeForm(forms.Form):
     class Meta:
         fields = ('subscribe',)
 
-    def __init__(self, *args, user, discussion, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Build the layout to reflect the action the form will take.
 
         Accepts (and requires) a user and a discussion as keyword arguments.
         """
+        user = kwargs.pop('user')
+        discussion = kwargs.pop('discussion')
+
         to_subscribe = user not in discussion.subscribers.all()
 
         # setdefault is like 'get', but if it misses, puts the specified

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -45,17 +45,20 @@ class DiscussionSubscribeForm(forms.Form):
 
     helper = FormHelper()
     helper.form_class = 'form-horizontal'
-    helper.action = reverse_lazy('discussion-subscribe')
 
     class Meta:
         fields = ('subscribe',)
 
     def __init__(self, *args, **kwargs):
         """
-        Accept a value for the 'subscribe' variable, and build the layout
-        to reflect the action the form will take.
+        Build the layout to reflect the action the form will take.
+
+        Accepts (and requires) a user and a discussion as keyword arguments.
         """
-        to_subscribe = kwargs.pop('subscribe', True)
+        user = kwargs.pop('user')
+        discussion = kwargs.pop('discussion')
+
+        to_subscribe = user not in discussion.subscribers.all()
 
         # setdefault is like 'get', but if it misses, puts the specified
         # default into kwargs and returns *that* object.
@@ -70,3 +73,4 @@ class DiscussionSubscribeForm(forms.Form):
                 Submit('submit', button_text),
             ),
         )
+        self.helper.action = reverse_lazy('discussion-subscribe', pk=discussion.pk)

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -12,7 +12,6 @@ class AddComment(forms.ModelForm):
     helper.form_class = 'form-horizontal'
     helper.label_class = 'col-lg-2'
     helper.field_class = 'col-lg-8'
-    helper.form_tag = True
     helper.layout = Layout(
         'body',
         FormActions(
@@ -44,10 +43,6 @@ class DiscussionCreate(forms.Form):
 class DiscussionSubscribeForm(forms.Form):
     subscribe = forms.BooleanField(widget=forms.HiddenInput(), required=False)
 
-    helper = FormHelper()
-    helper.form_class = 'form-horizontal'
-    helper.form_tag = True
-
     class Meta:
         fields = ('subscribe',)
 
@@ -67,6 +62,9 @@ class DiscussionSubscribeForm(forms.Form):
         super(DiscussionSubscribeForm, self).__init__(*args, **kwargs)
 
         button_text = 'Subscribe' if to_subscribe else 'Unsubscribe'
+
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-horizontal'
         self.helper.layout = Layout(
             FormActions(
                 Submit('subscribe-submit', button_text),

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -51,15 +51,12 @@ class DiscussionSubscribeForm(forms.Form):
     class Meta:
         fields = ('subscribe',)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, user, discussion, *args, **kwargs):
         """
         Build the layout to reflect the action the form will take.
 
         Accepts (and requires) a user and a discussion as keyword arguments.
         """
-        user = kwargs.pop('user')
-        discussion = kwargs.pop('discussion')
-
         to_subscribe = user not in discussion.subscribers.all()
 
         # setdefault is like 'get', but if it misses, puts the specified

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -12,10 +12,11 @@ class AddComment(forms.ModelForm):
     helper.form_class = 'form-horizontal'
     helper.label_class = 'col-lg-2'
     helper.field_class = 'col-lg-8'
+    helper.form_tag = True
     helper.layout = Layout(
         'body',
         FormActions(
-            Submit('submit', 'Post comment'),
+            Submit('comment-submit', 'Post comment'),
         ),
     )
 
@@ -45,6 +46,7 @@ class DiscussionSubscribeForm(forms.Form):
 
     helper = FormHelper()
     helper.form_class = 'form-horizontal'
+    helper.form_tag = True
 
     class Meta:
         fields = ('subscribe',)
@@ -70,7 +72,10 @@ class DiscussionSubscribeForm(forms.Form):
         button_text = 'Subscribe' if to_subscribe else 'Unsubscribe'
         self.helper.layout = Layout(
             FormActions(
-                Submit('submit', button_text),
+                Submit('subscribe-submit', button_text),
             ),
         )
-        self.helper.action = reverse_lazy('discussion-subscribe', pk=discussion.pk)
+        self.helper.form_action = reverse_lazy(
+            'discussion-subscribe',
+            kwargs={'pk': discussion.pk},
+        )

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -51,15 +51,12 @@ class DiscussionSubscribeForm(forms.Form):
     class Meta:
         fields = ('subscribe',)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, user, discussion, **kwargs):
         """
         Build the layout to reflect the action the form will take.
 
         Accepts (and requires) a user and a discussion as keyword arguments.
         """
-        user = kwargs.pop('user')
-        discussion = kwargs.pop('discussion')
-
         to_subscribe = user not in discussion.subscribers.all()
 
         # setdefault is like 'get', but if it misses, puts the specified

--- a/groups/models.py
+++ b/groups/models.py
@@ -17,6 +17,7 @@ class CommentManager(models.Manager):
 class Group(models.Model):
     """
     A model for a discussion group, similar to a forum.
+
     Groups can be private, in which case users have to request to join before
     they can read and/or watch the group.  The 'members' field stores such
     users, and isn't used by non-private groups.

--- a/groups/templates/groups/base.html
+++ b/groups/templates/groups/base.html
@@ -4,9 +4,9 @@
     {% block groups_title %}{% endblock groups_title %}
 {% endblock title %}
 
-{% block main_head_subtitle %}
+{% block subtitle %}
     {% block groups_subtitle %}{% endblock groups_subtitle %}
-{% endblock main_head_subtitle %}
+{% endblock subtitle %}
 
 {% block main_content %}
     {% block back_link %}{% endblock back_link %}

--- a/groups/templates/groups/base.html
+++ b/groups/templates/groups/base.html
@@ -4,10 +4,11 @@
     {% block groups_title %}{% endblock groups_title %}
 {% endblock title %}
 
-{% block subtitle %}
+{% block main_head_subtitle %}
     {% block groups_subtitle %}{% endblock groups_subtitle %}
-{% endblock subtitle %}
+{% endblock main_head_subtitle %}
 
 {% block main_content %}
+    {% block back_link %}{% endblock back_link %}
     {% block groups_main_content %}{% endblock groups_main_content %}
 {% endblock main_content %}

--- a/groups/templates/groups/discussion_form_base.html
+++ b/groups/templates/groups/discussion_form_base.html
@@ -8,6 +8,10 @@
     <h2>Start a new discussion about {{ group.name }}</h2>
 {% endblock groups_subtitle %}
 
+{% block back_link %}
+    <p><a href="{% url 'group-detail' pk=group.pk %}">Back to {{ group.name }}</a></p>
+{% endblock back_link %}
+
 {% block groups_main_content %}
     {% crispy form %}
 {% endblock groups_main_content %}

--- a/groups/templates/groups/discussion_thread_base.html
+++ b/groups/templates/groups/discussion_thread_base.html
@@ -13,6 +13,7 @@
 {% endblock back_link %}
 
 {% block groups_main_content %}
+    {% include "groups/subscribe_button.html" %}
     <ul>
         {% for comment in comments %}
             <li>

--- a/groups/templates/groups/discussion_thread_base.html
+++ b/groups/templates/groups/discussion_thread_base.html
@@ -8,6 +8,10 @@
     <h2>Comments on {{ discussion.name }}</h2>
 {% endblock groups_subtitle %}
 
+{% block back_link %}
+    <p><a href="{% url 'group-detail' pk=group.pk %}">Back to {{ group.name }}</a></p>
+{% endblock back_link %}
+
 {% block groups_main_content %}
     <ul>
         {% for comment in comments %}

--- a/groups/templates/groups/group_detail_base.html
+++ b/groups/templates/groups/group_detail_base.html
@@ -6,6 +6,10 @@
     <h2>Discussions on {{ group.name }}</h2>
 {% endblock groups_subtitle %}
 
+{% block back_link %}
+    <p><a href="{% url 'group-list' %}">Back to all groups</a></p>
+{% endblock back_link %}
+
 {% block groups_main_content %}
     <a href="{% url 'discussion-create' group.pk %}">Start a new discussion</a>
     <ul>

--- a/groups/templates/groups/subscribe_button_base.html
+++ b/groups/templates/groups/subscribe_button_base.html
@@ -1,5 +1,5 @@
 {% load crispy_forms_tags %}
 
 <div id="discussion-subscribe-button">
-    {% crispy form %}
+    {% crispy subscribe-form %}
 </div>

--- a/groups/tests/test_forms.py
+++ b/groups/tests/test_forms.py
@@ -1,5 +1,6 @@
 from incuna_test_utils.compat import Python2AssertMixin
 
+from . import factories
 from .utils import RequestTestCase
 from .. import forms, models
 
@@ -57,11 +58,20 @@ class TestDiscussionSubscribeForm(Python2AssertMixin, RequestTestCase):
         self.assertCountEqual(fields, expected)
 
     def test_form_valid(self):
-        form = self.form(data={})
+        discussion = factories.DiscussionFactory.create()
+        user = discussion.creator
+        form = self.form(data={}, user=user, discussion=discussion)
         self.assertTrue(form.is_valid(), msg=form.errors)
 
-    def test_initial(self):
-        form = self.form(subscribe=True)
+    def test_initial_subscribe(self):
+        discussion = factories.DiscussionFactory.create()
+        user = discussion.creator
+        form = self.form(user=user, discussion=discussion)
         self.assertTrue(form.initial['subscribe'])
-        form = self.form(subscribe=False)
+
+    def test_initial_unsubscribe(self):
+        discussion = factories.DiscussionFactory.create()
+        user = discussion.creator
+        discussion.subscribers.add(user)
+        form = self.form(user=user, discussion=discussion)
         self.assertFalse(form.initial['subscribe'])

--- a/groups/tests/test_groups_functional.py
+++ b/groups/tests/test_groups_functional.py
@@ -37,7 +37,7 @@ class TestGroupDetail(RenderedContentTestCase):
 class TestDiscussionThread(RenderedContentTestCase):
     view = views.DiscussionThread
 
-    def test_calendar_display(self):
+    def test_discussion_display(self):
         comment_body = 'I am a comment and proud of it!'
         discussion = factories.DiscussionFactory.create()
         comment = factories.CommentFactory.create(
@@ -48,7 +48,7 @@ class TestDiscussionThread(RenderedContentTestCase):
             discussion.name: True,
             comment_body: True,
             str(comment.user): True,
-            reverse('discussion-thread', kwargs={'pk': discussion.pk}): False,
+            reverse('discussion-subscribe', kwargs={'pk': discussion.pk}): True,
             'Post comment': True,  # The label on the 'add comment' button
             'type="submit"': True,  # The button itself
         }

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -2,7 +2,6 @@ import datetime
 
 import pytz
 from django.core.urlresolvers import reverse
-from django.http import Http404
 from incuna_test_utils.compat import Python2AssertMixin
 
 from . import factories
@@ -140,22 +139,6 @@ class TestDiscussionCreate(RequestTestCase):
 class TestDiscussionSubscribe(RequestTestCase):
     view_class = views.DiscussionSubscribe
 
-    def test_get_discussion(self):
-        discussion = factories.DiscussionFactory.create()
-        view = self.view_class()
-
-        # Assert that the discussion is found.
-        view.kwargs = {'pk': discussion.pk}
-        self.assertEqual(discussion, view.get_discussion())
-
-    def test_get_discussion_404(self):
-        view = self.view_class()
-
-        # Assert we get a 404 when we miss.
-        view.kwargs = {'pk': 42424242}
-        with(self.assertRaises(Http404)):
-            view.get_discussion()
-
     def test_form_subscribe(self):
         discussion = factories.DiscussionFactory.create()
         user = self.user_factory.create()
@@ -184,22 +167,3 @@ class TestDiscussionSubscribe(RequestTestCase):
         # Assert that the user is now unsubscribed.
         self.assertNotIn(user, discussion.subscribers.all())
         self.assertNotIn(discussion, user.subscribed_discussions.all())
-
-    def test_get_form_kwargs(self):
-        discussion = factories.DiscussionFactory.create()
-        user = self.user_factory.create()
-
-        # Feed the correct data into the view, so we can call get_form_kwargs.
-        request = self.create_request('get', user=user)
-        view = self.view_class()
-        view.request = request
-        view.kwargs = {'pk': discussion.pk}
-
-        # With an unsubscribed user, hitting this view should return
-        # subscribe=True.
-        self.assertTrue(view.get_form_kwargs()['subscribe'])
-
-        # Subscribe the user, then check again.  We should return
-        # subscribe=False now.
-        discussion.subscribers.add(user)
-        self.assertFalse(view.get_form_kwargs()['subscribe'])

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -127,11 +127,13 @@ class TestDiscussionCreate(RequestTestCase):
         view = self.view_class.as_view()
         response = view(request, pk=group.pk)
 
-        discussion = models.Discussion.objects.all()
-        self.assertEqual(len(discussion), 1)
+        discussion = models.Discussion.objects.get()  # will explode if it doesn't exist
+        self.assertEqual(discussion.creator, user)
+        self.assertEqual(discussion.subscribers.get(), user)
+        self.assertEqual(discussion.comments.get().body, 'Super sensible comment.')
 
         self.assertEqual(response.status_code, 302)
-        expected = reverse('discussion-thread', kwargs={'pk': discussion[0].pk})
+        expected = reverse('discussion-thread', kwargs={'pk': discussion.pk})
         self.assertEqual(response['Location'], expected)
 
 

--- a/groups/views.py
+++ b/groups/views.py
@@ -48,15 +48,17 @@ class DiscussionCreate(FormView):
         return reverse('discussion-thread', kwargs={'pk': self.pk})
 
     def form_valid(self, form):
+        user = self.request.user
         discussion = models.Discussion.objects.create(
-            creator=self.request.user,
+            creator=user,
             group=self.get_group(),
             name=form.cleaned_data['name'],
         )
+        discussion.subscribers.add(user)
         models.Comment.objects.create(
             body=form.cleaned_data['comment'],
             discussion=discussion,
-            user=self.request.user,
+            user=user,
         )
         self.pk = discussion.pk
         return super(DiscussionCreate, self).form_valid(form)

--- a/groups/views.py
+++ b/groups/views.py
@@ -65,7 +65,7 @@ class DiscussionCreate(FormView):
 
 
 class DiscussionThread(CreateView):
-    """Allows a user to read and comment on a Discussion."""
+    """Allow a user to read and comment on a Discussion."""
     model = models.Comment
     form_class = forms.AddComment
     subscribe_form_class = forms.DiscussionSubscribeForm
@@ -100,6 +100,7 @@ class DiscussionThread(CreateView):
 
 
 class DiscussionSubscribe(FormView):
+    """Provide an endpoint for the subscribe/unsubscribe button."""
     form_class = forms.DiscussionSubscribeForm
     template_name = 'groups/subscribe_button.html'
 

--- a/groups/views.py
+++ b/groups/views.py
@@ -68,8 +68,8 @@ class DiscussionThread(CreateView):
     template_name = 'groups/discussion_thread.html'
 
     def get_queryset(self):
-        """Display only the comments attached to a given discussion,
-        newest at the bottom.
+        """
+        Display only the comments attached to a given discussion, newest at the bottom.
         """
         return self.get_discussion().comments.all()
 
@@ -77,10 +77,7 @@ class DiscussionThread(CreateView):
         return models.Discussion.objects.get(pk=self.kwargs['pk'])
 
     def get_context_data(self, *args, **kwargs):
-        """
-        Attach the discussion and its existing comments to the context, so
-        they can be displayed.
-        """
+        """Attach the discussion and its existing comments to the context."""
         context = super(DiscussionThread, self).get_context_data(*args, **kwargs)
         context['comments'] = self.get_queryset()
         context['discussion'] = self.get_discussion()

--- a/groups/views.py
+++ b/groups/views.py
@@ -74,7 +74,7 @@ class DiscussionThread(CreateView):
     def dispatch(self, request, *args, **kwargs):
         pk = self.kwargs['pk']
         self.discussion = models.Discussion.objects.select_related('group').get(pk=pk)
-        return super().dispatch(request, *args, **kwargs)
+        return super(DiscussionThread, self).dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
         """
@@ -105,7 +105,7 @@ class DiscussionSubscribe(FormView):
 
     def dispatch(self, request, *args, **kwargs):
         self.discussion = get_object_or_404(models.Discussion, pk=self.kwargs['pk'])
-        return super().dispatch(request, *args, **kwargs)
+        return super(DiscussionSubscribe, self).dispatch(request, *args, **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super(DiscussionSubscribe, self).get_form_kwargs()

--- a/groups/views.py
+++ b/groups/views.py
@@ -6,12 +6,14 @@ from . import forms, models
 
 
 class GroupList(ListView):
+    """Show a top-level list of discussion groups."""
     model = models.Group
     paginate_by = 5
     template_name = 'groups/group_list.html'
 
 
 class GroupDetail(ListView):
+    """Show the discussions belonging to a group."""
     model = models.Discussion
     paginate_by = 5
     template_name = 'groups/group_detail.html'
@@ -30,6 +32,7 @@ class GroupDetail(ListView):
 
 
 class DiscussionCreate(FormView):
+    """Start a new discussion by writing its first comment."""
     form_class = forms.DiscussionCreate
     template_name = 'groups/discussion_form.html'
 
@@ -60,9 +63,7 @@ class DiscussionCreate(FormView):
 
 
 class DiscussionThread(CreateView):
-    """
-    Comment on a Discussion
-    """
+    """Allows a user to read and comment on a Discussion."""
     model = models.Comment
     form_class = forms.AddComment
     template_name = 'groups/discussion_thread.html'

--- a/groups/views.py
+++ b/groups/views.py
@@ -67,6 +67,9 @@ class DiscussionThread(CreateView):
     form_class = forms.AddComment
     template_name = 'groups/discussion_thread.html'
 
+    def get_group(self):
+        return self.get_discussion().group
+
     def get_queryset(self):
         """
         Display only the comments attached to a given discussion, newest at the bottom.
@@ -81,6 +84,7 @@ class DiscussionThread(CreateView):
         context = super(DiscussionThread, self).get_context_data(*args, **kwargs)
         context['comments'] = self.get_queryset()
         context['discussion'] = self.get_discussion()
+        context['group'] = self.get_group()
         return context
 
     def form_valid(self, form):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 -e .
 colour-runner==0.0.4
 coverage==3.7.1
-django==1.7.7
 dj-database-url==0.3.0
 factory_boy==2.4.1
 flake8==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 setup(
-    version='0.1',
+    version='0.1.1',
     name='incuna-groups',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
I found a few places where the templates in `incuna-groups` could use some love, and the subscribe functionality was yet to be implemented.  I've applied love and implementation respectively!

* Added some docstrings.
* Tweaked `base.html`.
* Added "back to [parent page]" links to some of the templates.
* A user is automatically subscribed to discussions they create.
* Streamlined and fixed the subscribe code.

@incuna/backend review please? :)