### PR TITLE
Add permalinks to comments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+Upcoming
+------
+
+* Add permalinks to comments.
+
+
 v0.2.0
 ------
 

--- a/groups/models.py
+++ b/groups/models.py
@@ -83,11 +83,14 @@ class Comment(models.Model):
         ordering = ('date_created',)
 
     def get_pagejump_anchor(self):
+        """Return a string suitable for use in a page jump to this comment."""
         return 'c{}'.format(self.pk)
 
     def get_pagejump(self):
+        """Return the URL suffix that'll jump to this comment's anchor point."""
         return '#' + self.get_pagejump_anchor()
 
     def get_absolute_url(self):
+        """Return a permalink that'll scroll to this comment on the page."""
         url = reverse('discussion-thread', kwargs={'pk': self.discussion.pk})
         return url + self.get_pagejump()

--- a/groups/models.py
+++ b/groups/models.py
@@ -82,5 +82,12 @@ class Comment(models.Model):
     class Meta:
         ordering = ('date_created',)
 
+    def get_pagejump_anchor(self):
+        return 'c{}'.format(self.pk)
+
+    def get_pagejump(self):
+        return '#' + self.get_pagejump_anchor()
+
     def get_absolute_url(self):
-        return reverse('discussion-thread', kwargs={'pk': self.discussion.pk})
+        url = reverse('discussion-thread', kwargs={'pk': self.discussion.pk})
+        return url + self.get_pagejump()

--- a/groups/templates/groups/discussion_thread_base.html
+++ b/groups/templates/groups/discussion_thread_base.html
@@ -18,9 +18,11 @@
         {% for comment in comments %}
             <li>
                 <ul>
+                    <li>
+                        <a name="{{ comment.get_pagejump_anchor }}"></a>
+                        {{ comment.user }} wrote at <a href="{{ comment.get_pagejump }}">{{ comment.date_created }}</a>:
+                    </li>
                     <li>{{ comment.body }}</li>
-                    <li>{{ comment.user }}</li>
-                    <li>{{ comment.date_created }}</li>
                 </ul>
             </li>
         {% endfor %}

--- a/groups/templates/groups/discussion_thread_base.html
+++ b/groups/templates/groups/discussion_thread_base.html
@@ -17,9 +17,8 @@
     <ul>
         {% for comment in comments %}
             <li>
-                <ul>
+                <ul id="{{ comment.get_pagejump_anchor }}">
                     <li>
-                        <a name="{{ comment.get_pagejump_anchor }}"></a>
                         {{ comment.user }} wrote at <a href="{{ comment.get_pagejump }}">{{ comment.date_created }}</a>:
                     </li>
                     <li>{{ comment.body }}</li>

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -95,7 +95,17 @@ class TestComment(Python2AssertMixin, TestCase):
         ])
         self.assertCountEqual(fields, expected)
 
+    def test_get_pagejump_anchor(self):
+        comment = factories.CommentFactory.create()
+        expected = 'c{}'.format(comment.pk)
+        self.assertEqual(comment.get_pagejump_anchor(), expected)
+
+    def test_get_pagejump(self):
+        comment = factories.CommentFactory.create()
+        expected = '#c{}'.format(comment.pk)
+        self.assertEqual(comment.get_pagejump(), expected)
+
     def test_get_absolute_url(self):
         comment = factories.CommentFactory.create()
-        expected = '/groups/discussions/{}/'.format(comment.discussion.pk)
+        expected = '/groups/discussions/{}/#c{}'.format(comment.discussion.pk, comment.pk)
         self.assertEqual(comment.get_absolute_url(), expected)


### PR DESCRIPTION
A comment's get_absolute_url() now includes a page jump.  The comment's creation time links to this so that users have access to the permalinks too.

@incuna/backend review please?