### PR TITLE
Add the ability to delete comments

### DIFF
--- a/groups/migrations/0008_comment_state.py
+++ b/groups/migrations/0008_comment_state.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('groups', '0007_change_ordering'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='comment',
+            name='state',
+            field=models.CharField(max_length=255, default='ok', choices=[('ok', 'OK'), ('deleted', 'Deleted')]),
+            preserve_default=True,
+        ),
+    ]

--- a/groups/models.py
+++ b/groups/models.py
@@ -16,7 +16,11 @@ class CommentQuerySet(models.query.QuerySet):
         return self.filter(discussion_id=pk)
 
     def with_user_may_delete(self, user):
-        """Return a list to avoid removing the added variable with further filters."""
+        """
+        Return a list to avoid removing the added variable with further filters.
+
+        Can still be chained onto the end of other queryset operations.
+        """
         comments = list(self)
         for comment in comments:
             comment.user_may_delete = comment.may_be_deleted(user)

--- a/groups/models.py
+++ b/groups/models.py
@@ -13,6 +13,13 @@ class CommentManager(models.Manager):
     def for_discussion_pk(self, pk):
         return self.get_queryset().filter(discussion_id=pk)
 
+    def with_user_may_delete(self, user):
+        queryset = self.get_queryset()
+        for comment in queryset:
+            comment.user_may_delete = comment.may_be_deleted(user)
+
+        return queryset
+
 
 class Group(models.Model):
     """

--- a/groups/models.py
+++ b/groups/models.py
@@ -103,6 +103,19 @@ class Comment(models.Model):
         url = reverse('discussion-thread', kwargs={'pk': self.discussion.pk})
         return url + self.get_pagejump()
 
+    def may_be_deleted(self, user):
+        """Return true if the user is allowed to delete this comment, false otherwise."""
+        if self.is_deleted():
+            return False
+
+        if user.is_superuser or user.is_staff:
+            return True
+
+        if user.pk == self.user.pk:
+            return True
+
+        return False
+
     def delete_state(self):
         """
         Cause this comment to show as deleted.

--- a/groups/templates/groups/comment_delete.html
+++ b/groups/templates/groups/comment_delete.html
@@ -1,0 +1,1 @@
+{% extends 'groups/comment_delete_base.html' %}

--- a/groups/templates/groups/comment_delete_base.html
+++ b/groups/templates/groups/comment_delete_base.html
@@ -1,0 +1,27 @@
+{% extends "groups/base.html" %}
+
+{% block groups_title %}Delete Comment{% endblock groups_title %}
+
+{% block groups_subtitle %}
+    <h2>Delete Comment</h2>
+{% endblock groups_subtitle %}
+
+{% block back_link %}
+    <p><a href="{{ object.get_absolute_url }}">Back to discussion</a></p>
+{% endblock back_link %}
+
+{% block groups_main_content %}
+    <p>Are you sure you want to delete this comment?</p>
+    <ul>
+        <li>
+            {{ comment.user }} wrote at {{ comment.date_created }}:
+        </li>
+        <li>{{ comment.body }}</li>
+    </ul>
+
+    <form action="{% url 'comment-delete' pk=object.pk %}" method="post">
+        {% csrf_token %}
+        <input type="submit" name="delete" value="Yes, delete this comment">
+        <p><a href="{{ object.get_absolute_url }}">No, don't delete this comment</a></p>
+    </form>
+{% endblock groups_main_content %}

--- a/groups/templates/groups/discussion_thread_base.html
+++ b/groups/templates/groups/discussion_thread_base.html
@@ -20,8 +20,15 @@
                 <ul id="{{ comment.get_pagejump_anchor }}">
                     <li>
                         {{ comment.user }} wrote at <a href="{{ comment.get_pagejump }}">{{ comment.date_created }}</a>:
+                        {% if comment.user_may_delete %}(<a href="{% url 'comment-delete' pk=comment.pk %}">delete this comment</a>){% endif %}
                     </li>
-                    <li>{{ comment.body }}</li>
+                    <li>
+                        {% if comment.is_deleted %}
+                            (Post deleted)
+                        {% else %}
+                            {{ comment.body }}
+                        {% endif %}
+                    </li>
                 </ul>
             </li>
         {% endfor %}

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -19,13 +19,23 @@ class TestDiscussionManager(Python2AssertMixin, TestCase):
 
 
 class TestCommentManager(Python2AssertMixin, TestCase):
-    def test_for_group_pk(self):
+    def test_for_discussion_pk(self):
         discussion = factories.DiscussionFactory.create()
         comment = factories.CommentFactory.create(discussion=discussion)
         factories.CommentFactory.create()
 
         results = models.Comment.objects.for_discussion_pk(discussion.pk)
         self.assertCountEqual([comment], results)
+
+    def test_with_user_may_delete(self):
+        comment_one = factories.CommentFactory.create()
+        comment_two = factories.CommentFactory.create()
+
+        results = models.Comment.objects.with_user_may_delete(comment_one.user)
+        self.assertCountEqual([comment_one, comment_two], results)
+
+        may_delete_values = [comment.user_may_delete for comment in results]
+        self.assertCountEqual([True, False], may_delete_values)
 
 
 class TestGroup(Python2AssertMixin, TestCase):

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -92,6 +92,7 @@ class TestComment(Python2AssertMixin, TestCase):
             'user',
             'user_id',
             'date_created',
+            'state',
         ])
         self.assertCountEqual(fields, expected)
 
@@ -109,3 +110,15 @@ class TestComment(Python2AssertMixin, TestCase):
         comment = factories.CommentFactory.create()
         expected = '/groups/discussions/{}/#c{}'.format(comment.discussion.pk, comment.pk)
         self.assertEqual(comment.get_absolute_url(), expected)
+
+    def test_delete_state(self):
+        comment = factories.CommentFactory.create()
+        self.assertEqual(comment.state, comment.STATE_OK)
+        comment.delete_state()
+        self.assertEqual(comment.state, comment.STATE_DELETED)
+
+    def test_is_deleted(self):
+        comment = factories.CommentFactory.create()
+        self.assertFalse(comment.is_deleted())
+        comment.delete_state()
+        self.assertTrue(comment.is_deleted())

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -111,6 +111,25 @@ class TestComment(Python2AssertMixin, TestCase):
         expected = '/groups/discussions/{}/#c{}'.format(comment.discussion.pk, comment.pk)
         self.assertEqual(comment.get_absolute_url(), expected)
 
+    def test_may_be_deleted_comment_user(self):
+        comment = factories.CommentFactory.create()
+        self.assertTrue(comment.may_be_deleted(comment.user))
+
+    def test_may_be_deleted_admin(self):
+        comment = factories.CommentFactory.create()
+        admin = factories.AdminFactory.create()
+        self.assertTrue(comment.may_be_deleted(admin))
+
+    def test_may_be_deleted_other_user(self):
+        comment = factories.CommentFactory.create()
+        user = factories.UserFactory.create()
+        self.assertFalse(comment.may_be_deleted(user))
+
+    def test_may_be_deleted_already_deleted(self):
+        comment = factories.CommentFactory.create()
+        comment.delete_state()
+        self.assertFalse(comment.may_be_deleted(comment.user))
+
     def test_delete_state(self):
         comment = factories.CommentFactory.create()
         self.assertEqual(comment.state, comment.STATE_OK)

--- a/groups/tests/test_urls.py
+++ b/groups/tests/test_urls.py
@@ -44,3 +44,11 @@ class TestGroupUrls(URLTestCase):
             'discussion-subscribe',
             url_kwargs={'pk': self.pk}
         )
+
+    def test_comment_delete(self):
+        self.assert_url_matches_view(
+            views.CommentDelete,
+            '/groups/comments/{}/delete/'.format(self.pk),
+            'comment-delete',
+            url_kwargs={'pk': self.pk}
+        )

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -183,10 +183,16 @@ class TestCommentDelete(RequestTestCase):
         self.assertEqual(response.context_data['object'], self.comment)
 
     def test_get_forbidden(self):
-        """A user who isn't allowed to delete the comment sees a 403."""
+        """A user who isn't allowed to delete the comment sees an error message."""
         view = self.view_class.as_view()
-        response = view(self.create_request(), pk=self.comment.pk)
-        self.assertEqual(response.status_code, 403)
+        request = self.create_request()
+        response = view(request, pk=self.comment.pk)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['location'], self.comment.discussion.get_absolute_url())
+        self.assertEqual(
+            'You do not have permission to delete this comment.',
+            request._messages.store[0]
+        )
 
     def test_post(self):
         """POSTing to this endpoint deletes the comment."""
@@ -200,10 +206,16 @@ class TestCommentDelete(RequestTestCase):
         self.assertTrue(updated_comment.is_deleted())
 
     def test_post_forbidden(self):
-        """A user who isn't allowed to delete the comment sees a 403."""
+        """A user who isn't allowed to delete the comment sees an error message."""
         view = self.view_class.as_view()
-        response = view(self.create_request('post'), pk=self.comment.pk)
-        self.assertEqual(response.status_code, 403)
+        request = self.create_request('post')
+        response = view(request, pk=self.comment.pk)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['location'], self.comment.discussion.get_absolute_url())
+        self.assertEqual(
+            'You do not have permission to delete this comment.',
+            request._messages.store[0]
+        )
 
     def test_delete(self):
         view_obj = self.view_class(request=self.request, kwargs={'pk': self.comment.pk})

--- a/groups/urls.py
+++ b/groups/urls.py
@@ -29,4 +29,11 @@ urlpatterns = [
             name='discussion-subscribe',
         ),
     ])),
+    url(r'^comments/(?P<pk>\d+)/', include([
+        url(
+            r'^delete/$',
+            views.CommentDelete.as_view(),
+            name='comment-delete',
+        ),
+    ])),
 ]

--- a/groups/utils.py
+++ b/groups/utils.py
@@ -1,0 +1,18 @@
+from django.db import models
+
+
+class ChainedQuerySetManager(models.Manager):
+    """
+    Generic manager for querysets that need chainable methods.
+
+    This does the same thing as django 1.7's QuerySet.as_manager() for a wider variety
+    of Django versions.
+
+    A subclass requires a queryset_class attribute.
+    """
+    def __getattr__(self, name):
+        """Pass any called methods onto the queryset to make use of its chaining."""
+        return getattr(self.get_queryset(), name)
+
+    def get_queryset(self):
+        return self.queryset_class(self.model, using=self._db)

--- a/groups/views.py
+++ b/groups/views.py
@@ -150,7 +150,7 @@ class CommentDelete(DeleteView):
         """Disallow access to any user other than admins or the comment creator."""
         self.comment = self.get_object()
         if not self.comment.may_be_deleted(request.user):
-            message = 'A user may only delete their own comments.'
+            message = 'You do not have permission to delete this comment.'
             return HttpResponseForbidden(message)
 
         return super(CommentDelete, self).dispatch(request, *args, **kwargs)

--- a/groups/views.py
+++ b/groups/views.py
@@ -79,8 +79,14 @@ class DiscussionThread(CreateView):
         return super(DiscussionThread, self).dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        """Display the comments attached to a given discussion, newest at the bottom."""
-        return self.discussion.comments.all()
+        """
+        Display the comments attached to a given discussion, newest at the bottom.
+
+        Use the CommentManager's with_user_may_delete method to annotate each comment
+        with a value denoting if it can be deleted by the current user. This allows us
+        to conditionally display the delete link in the template.
+        """
+        return self.discussion.comments.with_user_may_delete(self.request.user)
 
     def get_context_data(self, *args, **kwargs):
         """Attach the discussion and its existing comments to the context."""


### PR DESCRIPTION
This adds a new view which deletes comments on POST and shows an "Are you sure?" form on GET.  It also shows a 'delete this comment' link next to all comments that the logged-in user is able to delete (their own comments, or anyone's if they are an admin; the link is hidden for already-deleted comments).  Deleted posts have their contents replaced by `(Post deleted)`.

@incuna/backend review please? :)