### PR TITLE
Add manager methods for active users

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@ Upcoming
 ------
 * Added new manager methods for accessing groups, discussions, comments and users.
 * Added an `AppConfig` in apps.py for ease of configuration.
-* Added new manager methods to return active groups, discussions, and comments.
-* Added a mixin that can be added to User managers or querysets to return active users.
+* Added new manager methods to return recent groups, discussions, and comments.
+* Added a mixin that can be added to User managers or querysets to return recent users.
 
 v0.3.1
 ------

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@ Upcoming
 * Added new manager methods for accessing groups, discussions, comments and users.
 * Added an `AppConfig` in apps.py for ease of configuration.
 * Added new manager methods to return active groups, discussions, and comments.
+* Added a mixin that can be added to User managers or querysets to return active users.
 
 v0.3.1
 ------

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 Upcoming
 ------
 * Added new manager methods for accessing groups, discussions, comments and users.
+* Added an `AppConfig` in apps.py for ease of configuration.
 
 v0.3.1
 ------

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@ Upcoming
 ------
 * Added new manager methods for accessing groups, discussions, comments and users.
 * Added an `AppConfig` in apps.py for ease of configuration.
+* Added new manager methods to return active groups, discussions, and comments.
 
 v0.3.1
 ------

--- a/groups/__init__.py
+++ b/groups/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'groups.apps.GroupsConfig'

--- a/groups/apps.py
+++ b/groups/apps.py
@@ -6,11 +6,9 @@ class GroupsConfig(AppConfig):
     Configuration for `groups`.
 
     Provides:
-    * default_active_threshold_days - a user is considered not to be active if they
-      haven't made a comment within the past [this value] days, and vice versa.  A
-      discussion or group is considered to be active if it has at least one active user.
-      This setting is a default, used only when a value isn't supplied manually to the
-      various methods that return active things.
+    * default_within_days - a default parameter for the `within_days` methods on some
+      of the model managers, which return items that were posted or posted to within
+      that time period.
     """
     name = 'groups'
-    default_active_threshold_days = 7
+    default_within_days = 7

--- a/groups/apps.py
+++ b/groups/apps.py
@@ -1,0 +1,16 @@
+from django.apps import AppConfig
+
+
+class GroupsConfig(AppConfig):
+    """
+    Configuration for `groups`.
+
+    Provides:
+    * default_active_threshold_days - a user is considered not to be active if they
+      haven't made a comment within the past [this value] days, and vice versa.  A
+      discussion or group is considered to be active if it has at least one active user.
+      This setting is a default, used only when a value isn't supplied manually to the
+      various methods that return active things.
+    """
+    name = 'groups'
+    default_active_threshold_days = 7

--- a/groups/managers.py
+++ b/groups/managers.py
@@ -108,3 +108,16 @@ class CommentManager(PolymorphicManager, CommentManagerMixin):
     """PolymorphicManager for BaseComments with custom methods."""
     def get_queryset(self):
         return CommentQuerySet(self.model, using=self._db)
+
+
+class ActiveUserQuerySetMixin:
+    """
+    A mixin that adds an active() method, returning users that have recently posted.
+
+    Can be mixed into a Manager or a QuerySet.  The method accepts a parameter for the
+    number of days in the past a user can have posted in order to be considered active,
+    which defaults to `default_active_threshold_days` in `GroupsConfig`.
+    """
+    def active(self, threshold_days=DEFAULT_ACTIVE_THRESHOLD):
+        threshold = get_threshold_date(threshold_days)
+        return self.filter(comments__date_created__gte=threshold)

--- a/groups/tests/test_apps.py
+++ b/groups/tests/test_apps.py
@@ -1,0 +1,11 @@
+from django.apps import apps as django_apps
+from django.test import TestCase
+
+
+class TestGroupsConfig(TestCase):
+    config = django_apps.get_app_config('groups')
+
+    def test_default_active_threshold_days(self):
+        """Assert this member exists and has the right value."""
+        value = self.config.default_active_threshold_days
+        self.assertEqual(value, 7)

--- a/groups/tests/test_apps.py
+++ b/groups/tests/test_apps.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 class TestGroupsConfig(TestCase):
     config = django_apps.get_app_config('groups')
 
-    def test_default_active_threshold_days(self):
+    def test_default_within_days(self):
         """Assert this member exists and has the right value."""
-        value = self.config.default_active_threshold_days
+        value = self.config.default_within_days
         self.assertEqual(value, 7)

--- a/groups/tests/test_managers.py
+++ b/groups/tests/test_managers.py
@@ -236,8 +236,8 @@ class TestCommentManager(Python2AssertMixin, TestCase):
         self.assertCountEqual([True, False], may_delete_values)
 
 
-class TestWithinDaysUserQuerySetMixin(Python2AssertMixin, TestCase):
-    mixin = managers.WithinDaysUserQuerySetMixin
+class TestWithinDaysQuerySetMixin(Python2AssertMixin, TestCase):
+    mixin = managers.WithinDaysQuerySetMixin
 
     def __init__(self, *args, **kwargs):
         """
@@ -249,13 +249,16 @@ class TestWithinDaysUserQuerySetMixin(Python2AssertMixin, TestCase):
 
         This mixin is intended for use with User models, so we'll proxy that.
         """
-        super(TestWithinDaysUserQuerySetMixin, self).__init__(*args, **kwargs)
+        super(TestWithinDaysQuerySetMixin, self).__init__(*args, **kwargs)
 
         class MixedInQuerySet(self.mixin, django_models.QuerySet):
             """A basic QuerySet extending the mixin."""
+            since_filter = 'comments__date_created__gte'
 
         class MixedInManager(self.mixin, django_models.Manager):
             """A basic Manager extending the mixin and using MixedInQuerySet."""
+            since_filter = 'comments__date_created__gte'
+
             def get_queryset(self):
                 return MixedInQuerySet(self.model, using=self._db)
 

--- a/groups/tests/test_managers.py
+++ b/groups/tests/test_managers.py
@@ -46,6 +46,22 @@ class TestGroupManager(Python2AssertMixin, TestCase):
         results = models.Group.objects.within_days()
         self.assertCountEqual([comment.discussion.group], results)
 
+    def test_within_time(self):
+        comment = factories.TextCommentFactory.create()
+        factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
+        delta = datetime.timedelta(hours=6)
+
+        results = models.Group.objects.within_time(delta)
+        self.assertCountEqual([comment.discussion.group], results)
+
+    def test_since(self):
+        comment = factories.TextCommentFactory.create()
+        factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
+        when = datetime.date(2000, 1, 1)
+
+        results = models.Group.objects.since(when)
+        self.assertCountEqual([comment.discussion.group], results)
+
     def test_within_days_distinct(self):
         """Assert that Group.objects.within_days() contains no duplicates."""
         group = factories.GroupFactory.create()
@@ -56,6 +72,14 @@ class TestGroupManager(Python2AssertMixin, TestCase):
         )
 
         self.assertCountEqual([group], models.Group.objects.within_days())
+
+    def test_within_time_distinct(self):
+        """Assert that Group.objects.within_time() contains no duplicates."""
+        group = factories.GroupFactory.create()
+        factories.TextCommentFactory.create_batch(2, discussion__group=group)
+        delta = datetime.timedelta(hours=6)
+
+        self.assertCountEqual([group], models.Group.objects.within_time(delta))
 
 
 class TestDiscussionManager(Python2AssertMixin, TestCase):
@@ -105,6 +129,22 @@ class TestDiscussionManager(Python2AssertMixin, TestCase):
         results = models.Discussion.objects.within_days()
         self.assertCountEqual([comment.discussion], results)
 
+    def test_within_time(self):
+        comment = factories.TextCommentFactory.create()
+        factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
+        delta = datetime.timedelta(hours=6)
+
+        results = models.Discussion.objects.within_time(delta)
+        self.assertCountEqual([comment.discussion], results)
+
+    def test_since(self):
+        comment = factories.TextCommentFactory.create()
+        factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
+        when = datetime.date(2000, 1, 1)
+
+        results = models.Discussion.objects.since(when)
+        self.assertCountEqual([comment.discussion], results)
+
     def test_within_days_distinct(self):
         """Assert that Discussion.objects.within_days() contains no duplicates."""
         discussion = factories.DiscussionFactory.create()
@@ -115,6 +155,14 @@ class TestDiscussionManager(Python2AssertMixin, TestCase):
         )
 
         self.assertCountEqual([discussion], models.Discussion.objects.within_days())
+
+    def test_within_time_distinct(self):
+        """Assert that Discussion.objects.within_time() contains no duplicates."""
+        discussion = factories.DiscussionFactory.create()
+        factories.TextCommentFactory.create_batch(2, discussion=discussion)
+        delta = datetime.timedelta(hours=6)
+
+        self.assertCountEqual([discussion], models.Discussion.objects.within_time(delta))
 
 
 class TestCommentManager(Python2AssertMixin, TestCase):
@@ -152,6 +200,21 @@ class TestCommentManager(Python2AssertMixin, TestCase):
         factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
 
         self.assertCountEqual([comment], models.BaseComment.objects.within_days())
+
+    def test_within_time(self):
+        comment = factories.TextCommentFactory.create()
+        factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
+        delta = datetime.timedelta(hours=6)
+
+        self.assertCountEqual([comment], models.BaseComment.objects.within_time(delta))
+
+    def test_since(self):
+        comment = factories.TextCommentFactory.create()
+        factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
+        when = datetime.date(2000, 1, 1)
+
+        results = models.BaseComment.objects.since(when)
+        self.assertCountEqual([comment], results)
 
     def test_chaining(self):
         """Assert that chaining some of the above methods together works properly."""
@@ -210,12 +273,32 @@ class TestWithinDaysUserQuerySetMixin(Python2AssertMixin, TestCase):
         factories.TextCommentFactory.create(user=self.recent_user)
         factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
 
-    def test_mixin_in_manager(self):
+    def test_within_days_in_manager(self):
         """Assert that within_days() works properly when called from the manager."""
         results = self.model.objects.within_days()
         self.assertCountEqual([self.recent_user], results)
 
-    def test_mixin_in_queryset(self):
+    def test_within_days_in_queryset(self):
         """Assert that within_days() works properly when called from the queryset."""
         results = self.model.objects.all().within_days()
+        self.assertCountEqual([self.recent_user], results)
+
+    def test_within_time_in_manager(self):
+        """Assert that within_time() works properly when called from the manager."""
+        results = self.model.objects.within_time(datetime.timedelta(hours=6))
+        self.assertCountEqual([self.recent_user], results)
+
+    def test_within_time_in_queryset(self):
+        """Assert that within_time() works properly when called from the queryset."""
+        results = self.model.objects.all().within_time(datetime.timedelta(hours=6))
+        self.assertCountEqual([self.recent_user], results)
+
+    def test_since_in_manager(self):
+        """Assert that since() works properly when called from the manager."""
+        results = self.model.objects.since(datetime.date(2000, 1, 1))
+        self.assertCountEqual([self.recent_user], results)
+
+    def test_since_in_queryset(self):
+        """Assert that since() works properly when called from the queryset."""
+        results = self.model.objects.all().since(datetime.date(2000, 1, 1))
         self.assertCountEqual([self.recent_user], results)

--- a/groups/tests/test_managers.py
+++ b/groups/tests/test_managers.py
@@ -39,15 +39,15 @@ class TestGroupManager(Python2AssertMixin, TestCase):
 
         self.assertCountEqual([user], models.Group.objects.users())
 
-    def test_active(self):
+    def test_within_days(self):
         comment = factories.TextCommentFactory.create(date_created=datetime.date.today())
         factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
 
-        results = models.Group.objects.active()
+        results = models.Group.objects.within_days()
         self.assertCountEqual([comment.discussion.group], results)
 
-    def test_active_distinct(self):
-        """Assert that Group.objects.active() contains no duplicates."""
+    def test_within_days_distinct(self):
+        """Assert that Group.objects.within_days() contains no duplicates."""
         group = factories.GroupFactory.create()
         factories.TextCommentFactory.create_batch(
             2,
@@ -55,7 +55,7 @@ class TestGroupManager(Python2AssertMixin, TestCase):
             discussion__group=group,
         )
 
-        self.assertCountEqual([group], models.Group.objects.active())
+        self.assertCountEqual([group], models.Group.objects.within_days())
 
 
 class TestDiscussionManager(Python2AssertMixin, TestCase):
@@ -98,15 +98,15 @@ class TestDiscussionManager(Python2AssertMixin, TestCase):
         results = models.Discussion.objects.for_group(group).comments()
         self.assertCountEqual([comment], results)
 
-    def test_active(self):
+    def test_within_days(self):
         comment = factories.TextCommentFactory.create(date_created=datetime.date.today())
         factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
 
-        results = models.Discussion.objects.active()
+        results = models.Discussion.objects.within_days()
         self.assertCountEqual([comment.discussion], results)
 
-    def test_active_distinct(self):
-        """Assert that Discussion.objects.active() contains no duplicates."""
+    def test_within_days_distinct(self):
+        """Assert that Discussion.objects.within_days() contains no duplicates."""
         discussion = factories.DiscussionFactory.create()
         factories.TextCommentFactory.create_batch(
             2,
@@ -114,7 +114,7 @@ class TestDiscussionManager(Python2AssertMixin, TestCase):
             discussion=discussion,
         )
 
-        self.assertCountEqual([discussion], models.Discussion.objects.active())
+        self.assertCountEqual([discussion], models.Discussion.objects.within_days())
 
 
 class TestCommentManager(Python2AssertMixin, TestCase):
@@ -147,11 +147,11 @@ class TestCommentManager(Python2AssertMixin, TestCase):
 
         self.assertCountEqual([user], models.BaseComment.objects.users())
 
-    def test_recent(self):
+    def test_within_days(self):
         comment = factories.TextCommentFactory.create(date_created=datetime.date.today())
         factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
 
-        self.assertCountEqual([comment], models.BaseComment.objects.recent())
+        self.assertCountEqual([comment], models.BaseComment.objects.within_days())
 
     def test_chaining(self):
         """Assert that chaining some of the above methods together works properly."""
@@ -173,8 +173,8 @@ class TestCommentManager(Python2AssertMixin, TestCase):
         self.assertCountEqual([True, False], may_delete_values)
 
 
-class TestActiveUserQuerySetMixin(Python2AssertMixin, TestCase):
-    mixin = managers.ActiveUserQuerySetMixin
+class TestWithinDaysUserQuerySetMixin(Python2AssertMixin, TestCase):
+    mixin = managers.WithinDaysUserQuerySetMixin
 
     def __init__(self, *args, **kwargs):
         """
@@ -186,7 +186,7 @@ class TestActiveUserQuerySetMixin(Python2AssertMixin, TestCase):
 
         This mixin is intended for use with User models, so we'll proxy that.
         """
-        super(TestActiveUserQuerySetMixin, self).__init__(*args, **kwargs)
+        super(TestWithinDaysUserQuerySetMixin, self).__init__(*args, **kwargs)
 
         class MixedInQuerySet(self.mixin, django_models.QuerySet):
             """A basic QuerySet extending the mixin."""
@@ -206,16 +206,16 @@ class TestActiveUserQuerySetMixin(Python2AssertMixin, TestCase):
         self.model = ProxyUser
 
     def setUp(self):
-        self.active_user = factories.UserFactory.create()
-        factories.TextCommentFactory.create(user=self.active_user)
+        self.recent_user = factories.UserFactory.create()
+        factories.TextCommentFactory.create(user=self.recent_user)
         factories.TextCommentFactory.create(date_created=datetime.date(1970, 1, 1))
 
     def test_mixin_in_manager(self):
-        """Assert that active() works properly when called from the manager."""
-        results = self.model.objects.active()
-        self.assertCountEqual([self.active_user], results)
+        """Assert that within_days() works properly when called from the manager."""
+        results = self.model.objects.within_days()
+        self.assertCountEqual([self.recent_user], results)
 
     def test_mixin_in_queryset(self):
-        """Assert that active() works properly when called from the queryset."""
-        results = self.model.objects.all().active()
-        self.assertCountEqual([self.active_user], results)
+        """Assert that within_days() works properly when called from the queryset."""
+        results = self.model.objects.all().within_days()
+        self.assertCountEqual([self.recent_user], results)


### PR DESCRIPTION
Although the notion of an 'active' user is a bit ill-defined, I've gone with a definition of "posted within the last X days" here (it can be expanded later if needs be), where X defaults to 7 (i.e. a week) and can be changed via an AppConfig.

@incuna/backend review please? :)