### PR TITLE
Add __str__() methods

### DIFF
--- a/groups/models.py
+++ b/groups/models.py
@@ -45,6 +45,9 @@ class Group(models.Model):
     def is_subscribed(self, user):
         return self.watchers.filter(id=user.pk).exists()
 
+    def __str__(self):
+        return self.name
+
 
 class Discussion(models.Model):
     """A model for a discussion thread in a group."""
@@ -86,6 +89,9 @@ class Discussion(models.Model):
 
     def is_subscribed(self, user):
         return self.subscribers.filter(id=user.pk).exists()
+
+    def __str__(self):
+        return self.name
 
 
 class BaseComment(PolymorphicModel):
@@ -160,6 +166,9 @@ class BaseComment(PolymorphicModel):
 
     def is_deleted(self):
         return self.state == self.STATE_DELETED
+
+    def __str__(self):
+        return 'Comment by {}'.format(self.user.get_full_name())
 
 
 class TextComment(BaseComment):

--- a/groups/models.py
+++ b/groups/models.py
@@ -168,7 +168,10 @@ class BaseComment(PolymorphicModel):
         return self.state == self.STATE_DELETED
 
     def __str__(self):
-        return 'Comment by {}'.format(self.user.get_full_name())
+        return '{} on Discussion #{}'.format(
+            self.__class__.__name__,
+            self.discussion_id
+        )
 
 
 class TextComment(BaseComment):

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -136,7 +136,10 @@ class TestBaseComment(Python2AssertMixin, TestCase):
         comment = factories.TextCommentFactory.create()
         self.assertEqual(
             str(comment),
-            'Comment by {}'.format(comment.user.get_full_name())
+            '{} on Discussion #{}'.format(
+                'TextComment',
+                comment.discussion_id
+            )
         )
 
 

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -26,6 +26,10 @@ class TestGroup(Python2AssertMixin, TestCase):
         expected = '/groups/{}/'.format(group.pk)
         self.assertEqual(group.get_absolute_url(), expected)
 
+    def test_str(self):
+        group = factories.GroupFactory.create()
+        self.assertEqual(str(group), group.name)
+
 
 class TestDiscussion(Python2AssertMixin, TestCase):
     def test_fields(self):
@@ -57,6 +61,10 @@ class TestDiscussion(Python2AssertMixin, TestCase):
         discussions = models.Discussion.objects.all()
         expected = [discussion_two, discussion_one]
         self.assertSequenceEqual(discussions, expected)
+
+    def test_str(self):
+        discussion = factories.DiscussionFactory.create()
+        self.assertEqual(str(discussion), discussion.name)
 
 
 class TestBaseComment(Python2AssertMixin, TestCase):
@@ -123,6 +131,13 @@ class TestBaseComment(Python2AssertMixin, TestCase):
         self.assertFalse(comment.is_deleted())
         comment.delete_state()
         self.assertTrue(comment.is_deleted())
+
+    def test_str(self):
+        comment = factories.TextCommentFactory.create()
+        self.assertEqual(
+            str(comment),
+            'Comment by {}'.format(comment.user.get_full_name())
+        )
 
 
 class TestTextComment(Python2AssertMixin, TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ dj-inmemorystorage==1.3.0
 django-webtest==1.7.8
 factory_boy==2.4.1
 flake8==2.4.0
-flake8-docstrings==0.2.1.post1
 flake8-import-order==0.5.3
 incuna-mail==3.0.0
 incuna-test-utils==6.2.7


### PR DESCRIPTION
We need `__str__`s for the benefit of the admin.  They are:

* `Group`: the group's name
* `Discussion`: the discussion's name
* `Comment`: ~~"Comment by [user.name]".~~ "[Comment type] on Discussion #[pk]".

(Also get rid of flake8-docstrings because it's just a pain.)

@incuna/backend quick review please? :)