### PR TITLE
Unrequire many-to-many fields, and hide some of them

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+Upcoming
+------
+
+* Hide `subscribers`, `ignorers` and `watchers` from the admin, since they aren't meant
+  to be editable there.
+* Make all the `ManyToManyFields` non-required.
+
 v1.0.2
 ------
 

--- a/groups/admin.py
+++ b/groups/admin.py
@@ -5,7 +5,8 @@ from .models import Discussion, Group
 
 @admin.register(Group)
 class GroupAdmin(admin.ModelAdmin):
-    filter_horizontal = ('moderators', 'watchers', 'members_if_private')
+    filter_horizontal = ('moderators', 'members_if_private')
+    exclude = ('watchers',)
 
     class Meta:
         model = Group
@@ -13,7 +14,7 @@ class GroupAdmin(admin.ModelAdmin):
 
 @admin.register(Discussion)
 class DiscussionAdmin(admin.ModelAdmin):
-    filter_horizontal = ('subscribers', 'ignorers')
+    exclude = ('subscribers', 'ignorers')
 
     class Meta:
         model = Discussion

--- a/groups/migrations/0015_unrequire_m2ms.py
+++ b/groups/migrations/0015_unrequire_m2ms.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('groups', '0014_discussion_ignorers'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='discussion',
+            name='ignorers',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, blank=True, related_name='ignored_discussions'),
+        ),
+        migrations.AlterField(
+            model_name='discussion',
+            name='subscribers',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, blank=True, related_name='subscribed_discussions'),
+        ),
+        migrations.AlterField(
+            model_name='group',
+            name='members_if_private',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, blank=True, related_name='private_groups_joined'),
+        ),
+        migrations.AlterField(
+            model_name='group',
+            name='moderators',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, blank=True, related_name='moderated_groups'),
+        ),
+        migrations.AlterField(
+            model_name='group',
+            name='watchers',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, blank=True, related_name='watched_groups'),
+        ),
+    ]

--- a/groups/models.py
+++ b/groups/models.py
@@ -21,14 +21,17 @@ class Group(models.Model):
     moderators = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         related_name='moderated_groups',
+        blank=True,
     )
     watchers = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         related_name='watched_groups',
+        blank=True,
     )
     members_if_private = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         related_name='private_groups_joined',
+        blank=True,
     )
 
     objects = managers.GroupQuerySet.as_manager()
@@ -61,10 +64,12 @@ class Discussion(models.Model):
     subscribers = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         related_name='subscribed_discussions',
+        blank=True,
     )
     ignorers = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         related_name='ignored_discussions',
+        blank=True,
     )
 
     objects = managers.DiscussionQuerySet.as_manager()


### PR DESCRIPTION
The admin currently demands that you add at least some moderators and members to a group, and exposes some internal many-to-many relationships (subscribers, ignorers, watchers) that it shouldn't.  This shall not do!

@incuna/backend review please?