### PR TITLE
Add email replies

### DIFF
--- a/groups/models.py
+++ b/groups/models.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core import signing
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.template import loader, RequestContext
@@ -94,6 +95,10 @@ class Discussion(models.Model):
 
     def is_subscribed(self, user):
         return self.subscribers.filter(id=user.pk).exists()
+
+    def generate_reply_uuid(self, user):
+        data = {'discussion_pk': self.pk, 'user_pk': user.pk}
+        return signing.dumps(data)
 
     def __str__(self):
         return self.name

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -1,3 +1,4 @@
+from django.core import signing
 from django.test import TestCase
 from incuna_test_utils.compat import Python2AssertMixin
 
@@ -65,6 +66,17 @@ class TestDiscussion(Python2AssertMixin, TestCase):
     def test_str(self):
         discussion = factories.DiscussionFactory.create()
         self.assertEqual(str(discussion), discussion.name)
+
+    def test_generate_reply_uuid(self):
+        discussion = factories.DiscussionFactory.create()
+        user = discussion.creator
+        expected_data = {
+            'discussion_pk': discussion.pk,
+            'user_pk': user.pk,
+        }
+
+        signed_data = discussion.generate_reply_uuid(user)
+        self.assertEqual(signing.loads(signed_data), expected_data)
 
 
 class TestBaseComment(Python2AssertMixin, TestCase):

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -20,10 +20,10 @@ class TestGetReplyAddress(RequestTestCase):
         discussion = factories.DiscussionFactory.create()
 
         domain = get_current_site(request).domain
-        uuid_regex = r'[\d\w\-_:]*'
+        uuid_regex = r'[\d\w\-_:]*'  # A string of alphanumerics, `-`, `_`, and/or `:`
         self.assertRegex(
             views.get_reply_address(discussion, request.user, request),
-            r'reply-{}@{}'.format(uuid_regex, domain)
+            r'reply-{uuid}@{domain}'.format(uuid=uuid_regex, domain=domain)
         )
 
 

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -1,11 +1,8 @@
 import datetime
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import pytz
+from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django_webtest import WebTest
@@ -14,6 +11,20 @@ from incuna_test_utils.compat import Python2AssertMixin
 from . import factories
 from .utils import RequestTestCase
 from .. import models, views
+
+
+class TestGetReplyAddress(RequestTestCase):
+    def test_get_reply_address(self):
+        """Assert that the method returns `reply-{uuid}@{domain}`."""
+        request = self.create_request()
+        discussion = factories.DiscussionFactory.create()
+
+        domain = get_current_site(request).domain
+        uuid_regex = r'[\d\w\-_:]*'
+        self.assertRegex(
+            views.get_reply_address(discussion, request.user, request),
+            r'reply-{}@{}'.format(uuid_regex, domain)
+        )
 
 
 class TestGroupList(Python2AssertMixin, RequestTestCase):

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -1,6 +1,10 @@
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import datetime
 import json
-from unittest import mock
 
 import pytz
 from django.contrib.sites.shortcuts import get_current_site

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -20,7 +20,7 @@ from .utils import RequestTestCase
 from .. import models, views
 
 
-class TestGetReplyAddress(RequestTestCase):
+class TestGetReplyAddress(Python2AssertMixin, RequestTestCase):
     def test_get_reply_address(self):
         """Assert that the method returns `reply-{uuid}@{domain}`."""
         request = self.create_request()

--- a/groups/urls.py
+++ b/groups/urls.py
@@ -46,4 +46,9 @@ urlpatterns = [
             name='comment-delete',
         ),
     ])),
+    url(
+        r'^reply/',
+        views.CommentPostByEmail.as_view(),
+        name='comment-reply',
+    ),
 ]

--- a/groups/views.py
+++ b/groups/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import signing
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, Http404
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.views.generic import CreateView, FormView, ListView, View
 from django.views.generic.detail import SingleObjectMixin

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.contrib import messages
+from django.contrib.sites.shortcuts import get_current_site
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -10,9 +11,14 @@ from incuna_mail import send
 
 from . import forms, models
 
-
 NEW_DISCUSSION_SUBJECT = apps.get_app_config('groups').new_discussion_subject
 NEW_COMMENT_SUBJECT = apps.get_app_config('groups').new_comment_subject
+
+
+def get_reply_address(discussion, user, request):
+    uuid = discussion.generate_reply_uuid(user)
+    site = get_current_site(request)
+    return 'reply-{}@{}'.format(uuid, site)
 
 
 class GroupList(ListView):

--- a/groups/views.py
+++ b/groups/views.py
@@ -132,10 +132,11 @@ class DiscussionCreate(FormView):
                 to=user.email,
                 subject=NEW_DISCUSSION_SUBJECT.format(group=discussion.group.name),
                 template_name='groups/emails/new_discussion.txt',
+                reply_to=get_reply_address(discussion, user, self.request),
                 context={
                     'discussion': discussion,
                     'user': user,
-                }
+                },
             )
 
 
@@ -190,10 +191,11 @@ class CommentPostView(CreateView):
                 to=user.email,
                 subject=NEW_COMMENT_SUBJECT.format(discussion=comment.discussion.name),
                 template_name='groups/emails/new_comment.txt',
+                reply_to=get_reply_address(comment.discussion, user, self.request),
                 context={
                     'comment': comment,
                     'user': user,
-                }
+                },
             )
 
 

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,10 +1,14 @@
+import json
+
 from django.apps import apps
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
+from django.core import signing
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
-from django.views.generic import CreateView, FormView, ListView
+from django.views.generic import CreateView, FormView, ListView, View
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import DeleteView
 from incuna_mail import send
@@ -140,32 +144,8 @@ class DiscussionCreate(FormView):
             )
 
 
-class CommentPostView(CreateView):
-    """
-    Base class for views that post a comment to a particular discussion.
-
-    Must be initialised with form_class and template_name attributes, as required by
-    the superclass, CreateView.
-    """
-    model = models.BaseComment
-
-    def dispatch(self, request, *args, **kwargs):
-        pk = self.kwargs['pk']
-        self.discussion = models.Discussion.objects.select_related('group').get(pk=pk)
-        return super(CommentPostView, self).dispatch(request, *args, **kwargs)
-
-    def get_context_data(self, *args, **kwargs):
-        """Attach the discussion and its existing comments to the context."""
-        context = super(CommentPostView, self).get_context_data(*args, **kwargs)
-        context['discussion'] = self.discussion
-        return context
-
-    def form_valid(self, form):
-        form.instance.user = self.request.user
-        form.instance.discussion = self.discussion
-        self.email_subscribers(form.instance)
-        return super(CommentPostView, self).form_valid(form)
-
+class CommentEmailMixin:
+    """A mixin for CreateViews and similar that build comments."""
     @staticmethod
     def users_to_notify(comment):
         """
@@ -197,6 +177,33 @@ class CommentPostView(CreateView):
                     'user': user,
                 },
             )
+
+
+class CommentPostView(CommentEmailMixin, CreateView):
+    """
+    Base class for views that post a comment to a particular discussion.
+
+    Must be initialised with form_class and template_name attributes, as required by
+    the superclass, CreateView.
+    """
+    model = models.BaseComment
+
+    def dispatch(self, request, *args, **kwargs):
+        pk = self.kwargs['pk']
+        self.discussion = models.Discussion.objects.select_related('group').get(pk=pk)
+        return super(CommentPostView, self).dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, *args, **kwargs):
+        """Attach the discussion and its existing comments to the context."""
+        context = super(CommentPostView, self).get_context_data(*args, **kwargs)
+        context['discussion'] = self.discussion
+        return context
+
+    def form_valid(self, form):
+        form.instance.user = self.request.user
+        form.instance.discussion = self.discussion
+        self.email_subscribers(form.instance)
+        return super(CommentPostView, self).form_valid(form)
 
 
 class DiscussionThread(CommentPostView):
@@ -274,3 +281,38 @@ class CommentDelete(DeleteView):
 
     def get_success_url(self):
         return self.comment.get_absolute_url()
+
+
+class CommentPostByEmail(CommentEmailMixin, View):
+    """
+    Receive comments posted by email and create them in the database.
+
+    This view is intended to be linked to an endpoint that provides an URL kwarg
+    'uuid'.  This matches up to an EmailUUID object that stores the discussion and user
+    being used.
+    """
+    def dispatch(self, request, *args, **kwargs):
+        self.uuid = kwargs.pop('uuid')
+        return super(CommentPostByEmail, self).dispatch(request, *args, **kwargs)
+
+    @staticmethod
+    def get_uuid_data(uuid):
+        """Unwrap the discussion and user data in the UUID string."""
+        data = signing.loads(uuid)
+        return {
+            'discussion': get_object_or_404(models.Discussion, pk=data['discussion_pk']),
+            'user': get_object_or_404(get_user_model(), pk=data['user_pk'])
+        }
+
+    def post(self, request, *args, **kwargs):
+        """Create a new comment to self.pk."""
+        message = json.loads(request.body.decode())['message']
+        target = self.get_uuid_data(self.uuid)
+
+        content = message['stripped-text']
+        comment = models.TextComment.objects.create(
+            body=content,
+            user=target['user'],
+            discussion=target['discussion'],
+        )
+        self.email_subscribers(comment)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-webtest==1.7.8
 factory_boy==2.4.1
 flake8==2.4.0
 flake8-import-order==0.5.3
-incuna-mail==3.0.0
+incuna-mail==4.0.0
 incuna-test-utils==6.2.7
 Pillow==2.7.0
 psycopg2==2.6.0


### PR DESCRIPTION
We want users to be able to reply to a discussion by replying to the notification email itself.  This involves an endpoint, /groups/reply, that accepts Meldium POSTs full of JSON data.  The JSON is formatted according to [Mailgun's documentation](https://documentation.mailgun.com/user_manual.html#routes) - the fields we care about here are `body['message']['recipient']` and `body['message']['stripped-text']`.

The user is identified by a UUID generated by `django.core.signing` and pasted into a `reply-<uuid>@domain.com` email address.  This address is given as a `Reply-To` header in the email, and the UUID is extracted from it when the email is received.  I'd wanted to use an URL with a <uuid> argument, but Mailgun's routing doesn't seem to be sophisticated enough, unfortunately.

These `views` files are getting pretty huge, but I don't want to split them up in this PR since the diff is going to be substantial as it is.  I've made a [separate issue](https://github.com/incuna/incuna-groups/issues/27) for that refactor.

@incuna/backend review please?