### PR TITLE
Fix email replies (once more with feeling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ An extensible Django app, that provides forum functionality.
 - Create groups.
 - Create discussions on groups.
 - Comment on discussions.
+
+Email reply gotchas:
+- The `/groups/reply/` endpoint _has a trailing slash_.  Ensure that this slash is included in any Mailgun config otherwise you'll get a stream of HTTP301s.
+- If you're using `incuna_auth.LoginRequiredMiddleware`, make sure to add `/groups/reply/` to `LOGIN_EXEMPT_URLS` to avoid more 301s.

--- a/groups/tests/test_views_comments.py
+++ b/groups/tests/test_views_comments.py
@@ -192,7 +192,9 @@ class TestCommentPostByEmail(RequestTestCase):
         with mock.patch(self.extract_path, return_value='uuid') as extract_uuid:
             with mock.patch(self.uuid_path, return_value=uuid_data):
                 with mock.patch(self.email_path) as email_subscribers:
-                    view(request, uuid='use of this is mocked out')
+                    response = view(request, uuid='use of this is mocked out')
+
+        self.assertEqual(response.status_code, 200)
 
         # Assert that a comment was created, subscribers were emailed, and the
         # recipient field in the request data was respected.

--- a/groups/tests/test_views_comments.py
+++ b/groups/tests/test_views_comments.py
@@ -4,7 +4,6 @@ except ImportError:
     import mock
 
 import datetime
-import json
 
 import pytz
 from django.contrib.sites.shortcuts import get_current_site
@@ -149,14 +148,20 @@ class TestCommentPostByEmail(RequestTestCase):
             self.view_class.get_uuid_data(uuid)
 
     def test_extract_uuid_from_email(self):
-        """Assert that `reply-{uuid}@{domain}` becomes `uuid`."""
-        uuid = 'I-aM:an_UU1D'
+        """
+        Assert that `reply-{uuid}@{domain}` becomes `uuid`.
+
+        The UUID that is returned has had its dollar signs turned back into colons so
+        that it can be parsed properly.
+        """
+        reply_uuid = 'I-aM$an_UU1D'
+        expected_uuid = reply_uuid.replace('$', ':')
         request = self.create_request()
         domain = get_current_site(request).domain
-        email = 'reply-{}@{}'.format(uuid, domain)
+        email = 'reply-{}@{}'.format(reply_uuid, domain)
 
         extracted_uuid = self.view_class.extract_uuid_from_email(email, request)
-        self.assertEqual(extracted_uuid, uuid)
+        self.assertEqual(extracted_uuid, expected_uuid)
 
     def test_extract_uuid_failure(self):
         """The method throws a 404 when it fails."""
@@ -173,17 +178,15 @@ class TestCommentPostByEmail(RequestTestCase):
 
         message_body = 'Email replying is so straightforward and fun'
         request_data = {
-            'message': {
-                'stripped-text': message_body,
-                'recipient': 'this is needed, but mocked out',
-            }
+            'stripped-text': message_body,
+            'recipient': 'this is needed, but mocked out',
         }
 
         request = self.create_request(
             method='post',
-            data=json.dumps(request_data),
             content_type='application/json',
         )
+        request.POST = request_data
         view = self.view_class.as_view()
 
         with mock.patch(self.extract_path, return_value='uuid') as extract_uuid:
@@ -197,6 +200,6 @@ class TestCommentPostByEmail(RequestTestCase):
         self.assertEqual(comment.body, message_body)
         email_subscribers.assert_called_once_with(comment)
         extract_uuid.assert_called_once_with(
-            request_data['message']['recipient'],
+            request_data['recipient'],
             request
         )

--- a/groups/tests/test_views_helpers.py
+++ b/groups/tests/test_views_helpers.py
@@ -14,12 +14,17 @@ from ..views import _helpers as helpers
 
 class TestGetReplyAddress(Python2AssertMixin, RequestTestCase):
     def test_get_reply_address(self):
-        """Assert that the method returns `reply-{uuid}@{domain}`."""
+        """
+        Assert that the method returns `reply-{uuid}@{domain}`.
+
+        Look for dollar signs ($) instead of colons in the UUID, because we've done some
+        replace work to ensure the email address is legal.
+        """
         request = self.create_request()
         discussion = factories.DiscussionFactory.create()
 
         domain = get_current_site(request).domain
-        uuid_regex = r'[\d\w\-_:]*'  # A string of alphanumerics, `-`, `_`, and/or `:`
+        uuid_regex = r'[\d\w\-_$]*'  # A string of alphanumerics, `-`, `_`, and/or `$`
         self.assertRegex(
             helpers.get_reply_address(discussion, request.user, request),
             r'reply-{uuid}@{domain}'.format(uuid=uuid_regex, domain=domain)

--- a/groups/views/_helpers.py
+++ b/groups/views/_helpers.py
@@ -9,7 +9,17 @@ NEW_COMMENT_SUBJECT = apps.get_app_config('groups').new_comment_subject
 
 
 def get_reply_address(discussion, user, request):
-    uuid = discussion.generate_reply_uuid(user)
+    """
+    Wrap a discussion reply UUID in an email address suitable for use as a reply-to.
+
+    reply-{uuid}@{domain}
+
+    The UUID contains colons, which aren't allowed in email addresses, so swap those
+    out for dollar signs ($) as a placeholder using a string `replace`.  The rest of
+    the UUID is base64-encoded, so there will be neither colons nor dollar signs in it
+    (it's only alphanumerics, hyphens, and underscores).
+    """
+    uuid = discussion.generate_reply_uuid(user).replace(':', '$')
     site = get_current_site(request)
     return 'reply-{}@{}'.format(uuid, site)
 

--- a/groups/views/comments.py
+++ b/groups/views/comments.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 from django.apps import apps
@@ -6,9 +5,11 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import signing
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+
 from django.views.generic.edit import DeleteView
 
 from ._helpers import CommentEmailMixin, CommentPostView
@@ -95,8 +96,8 @@ class CommentPostByEmail(CommentEmailMixin, View):
     'uuid'.  This matches up to an EmailUUID object that stores the discussion and user
     being used.
     """
+    @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
-        self.uuid = kwargs.pop('uuid')
         return super(CommentPostByEmail, self).dispatch(request, *args, **kwargs)
 
     @staticmethod
@@ -110,18 +111,23 @@ class CommentPostByEmail(CommentEmailMixin, View):
 
     @staticmethod
     def extract_uuid_from_email(email, request):
-        """Turn `reply-{uuid}@domain.com` into just `uuid`."""
-        uuid_regex = r'(?P<uuid>[\w\d\-_:]+)'
+        """
+        Turn `reply-{uuid}@domain.com` into just `uuid`.
+
+        The UUIDs contain colons, which aren't allowed in email addresses, so they get
+        replaced with dollar signs in the `reply-to` address.  We have to undo that here.
+        """
+        uuid_regex = r'(?P<uuid>[\w\d\-_$]+)'
         regex = r'reply-{}@{}'.format(uuid_regex, get_current_site(request))
         match = re.compile(regex).match(email)
         if not match:
             raise Http404
 
-        return match.group('uuid')
+        return match.group('uuid').replace('$', ':')
 
     def post(self, request, *args, **kwargs):
         """Create a new comment to self.pk."""
-        message = json.loads(request.body.decode())['message']
+        message = request.POST
         uuid = self.extract_uuid_from_email(message['recipient'], request)
         target = self.get_uuid_data(uuid)
 
@@ -132,3 +138,4 @@ class CommentPostByEmail(CommentEmailMixin, View):
             discussion=target['discussion'],
         )
         self.email_subscribers(comment)
+        return HttpResponse(status=200)

--- a/groups/views/comments.py
+++ b/groups/views/comments.py
@@ -138,4 +138,5 @@ class CommentPostByEmail(CommentEmailMixin, View):
             discussion=target['discussion'],
         )
         self.email_subscribers(comment)
+
         return HttpResponse(status=200)


### PR DESCRIPTION
So it turns out that on an actual deployed server, my initial code was totally wrong.  Fixy fixy.  As well as parsing the Mailgun response incorrectly (the correct way is to use `request.POST` and do no `json.load`ing), I'd missed out a HTTP200 confirmation response, and gotten the wrong impression about the structure of Mailgun's data.  There were a couple more gotchas as well that I've added to the readme.  (I'm going to flesh out the readme something fierce this afternoon; the notes I've added are just reminders for now.)  A sombre warning of the pitfalls of relying on unit tests. :P

@incuna/backend review please?