### PR TITLE
Add file comments from email replies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This project uses Semantic Versioning (2.0).
 
+## Upcoming
+
+- Add the ability to post files to discussions by attaching them to email replies.
+
 ## v3.0.3
 
 - Send `Reply-To` UUIDs in email notifications with the colons replaced with dollar signs,


### PR DESCRIPTION
Users can make file comments on discussions by attaching files to their email replies.  At the moment, this just generates a (separate) `FileComment` per attachment on top of the normal `TextComment` added by the email body.  The `TextComment` comes last as per @meshy's suggestion, but I'm happy to reorder them.

File comments don't currently display properly - they really ought to link to the uploaded file and say "Uploaded a file: [filename]" rather than just "/groups/comments/[filename]" with no linking.  I'll fix that next.

I've tested this on the server and it worked!  First try!  This is entirely due to me finally finding some Mailgun API description... in a [blog post from 2011](http://blog.mailgun.com/handle-incoming-emails-like-a-pro-mailgun-api-2-0/).  Sigh.

@incuna/backend review please? :)