### PR TITLE
Improve file comment display

### DIFF
--- a/groups/models.py
+++ b/groups/models.py
@@ -194,3 +194,7 @@ class FileComment(BaseComment):
     """A comment with an uploaded file. No text."""
     file = models.FileField(upload_to='groups/file_comments')
     template_name = 'groups/file_comment.html'
+
+    def short_filename(self):
+        """Trim the `/groups/file_comments/` part off the front of the filename."""
+        return self.file.name[21:]

--- a/groups/templates/groups/file_comment.html
+++ b/groups/templates/groups/file_comment.html
@@ -1,5 +1,9 @@
 {% extends "groups/comment_base.html" %}
+{% load static %}
 
 {% block comment_visible %}
-    <p>{{ comment.file }}</p>
+    <p>
+        Uploaded a file:
+        <a href="{% get_media_prefix %}{{ comment.file }}">{{ comment.file.name|slice:"21:" }}</a>
+    </p>
 {% endblock comment_visible %}

--- a/groups/templates/groups/file_comment.html
+++ b/groups/templates/groups/file_comment.html
@@ -4,6 +4,6 @@
 {% block comment_visible %}
     <p>
         Uploaded a file:
-        <a href="{% get_media_prefix %}{{ comment.file }}">{{ comment.file.name|slice:"21:" }}</a>
+        <a href="{% get_media_prefix %}{{ comment.file }}">{{ comment.short_filename }}</a>
     </p>
 {% endblock comment_visible %}

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -195,3 +195,8 @@ class TestFileComment(Python2AssertMixin, TestCase):
             'basecomment_ptr_id',
         ]
         self.assertCountEqual(fields, expected)
+
+    def test_short_filename(self):
+        filename = '/groups/file_comments/name.txt'
+        comment = factories.FileCommentFactory.create(file__filename=filename)
+        self.assertEqual(comment.short_filename(), 'name.txt')


### PR DESCRIPTION
Add an "Uploaded a file:" label and remove the `/groups/file_comments/` part of the path.

@incuna/backend review please? :)