### PR TITLE
Make AddTextComment crispy-form suitable for use in DiscussionThread inline replies

### DIFF
--- a/groups/forms.py
+++ b/groups/forms.py
@@ -36,6 +36,25 @@ class AddTextComment(BaseAddCommentForm):
     class Meta(BaseAddCommentForm.Meta):
         model = models.TextComment
 
+    def build_helper(self):
+        """Remove the label from the 'body' field first."""
+        # Look at all the things I tried :'(
+        body_field = self.fields.get('body')
+        body_field.widget.attrs['placeholder'] = 'Write your comment here...'
+        body_field.label = False
+        helper = FormHelper()
+        helper.form_class = 'form-horizontal'
+        helper.label_class = 'col-lg-0'
+        helper.field_class = 'col-lg-10'
+        helper.form_show_labels = False
+        helper.layout = Layout(
+            'body',
+            FormActions(
+                StrictButton('Post comment', type='submit'),
+            ),
+        )
+        return helper
+
 
 class AddFileComment(BaseAddCommentForm):
     """A form that uploads FileComments."""


### PR DESCRIPTION
Don't merge this yet.  It is merely a record of my flailing attempts at getting this:

![ffs crispy-forms](https://cloud.githubusercontent.com/assets/6973481/11035933/5240f666-86ed-11e5-9593-9318ad3c6383.png)

to look like this:

![proper reply form](https://cloud.githubusercontent.com/assets/6973481/11035997/9e283238-86ed-11e5-9736-88829a2b1edc.png)