### PR TITLE
Update the copy on email templates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This project uses Semantic Versioning (2.0).
 
+## Upcoming
+
+- Improve email template copy.
+
 ## v3.1.0
 
 - Add the ability to post files to discussions by attaching them to email replies.

--- a/groups/templates/groups/emails/new_comment.txt
+++ b/groups/templates/groups/emails/new_comment.txt
@@ -1,9 +1,9 @@
-{% load i18n %}{% blocktrans with username=user.get_full_name name=comment.discussion.name creator=comment.creator.name %}Dear {{ username }},
+{% load i18n %}{% blocktrans with username=user.get_full_name name=comment.discussion.name creator=comment.user.name %}Dear {{ username }},
 
-A new comment has been posted to the discussion {{ name }} by {{ creator }}{% endblocktrans %}{% if comment.body %}:
+A new comment has been posted to the discussion "{{ name }}" by {{ creator }}{% endblocktrans %}{% if comment.body %}:
 
-{{ comment.body }}
+"{{ comment.body }}"
 
 {% else %}.{% endif %}
 
-{% blocktrans with url=comment.get_absolute_url %}Click here to reply online: {{ site.domain }}{{ url }}{% endblocktrans %}
+{% blocktrans with url=comment.get_absolute_url %}Reply to this email to post a response, or visit this URL to reply online: {{ site.domain }}{{ url }}{% endblocktrans %}

--- a/groups/templates/groups/emails/new_discussion.txt
+++ b/groups/templates/groups/emails/new_discussion.txt
@@ -1,7 +1,7 @@
 {% load i18n %}{% blocktrans with username=user.get_full_name name=discussion.name group=discussion.group.name creator=discussion.creator.name %}Dear {{ username }},
 
-A new discussion "{{ name }}" has been posted to the group {{ group }} by {{ creator }}{% endblocktrans %}{% if discussion.comments.first.body %}:
+A new discussion on "{{ name }}" has been posted to the {{ group }} group by {{ creator }}{% endblocktrans %}{% if discussion.comments.first.body %}:
 
-{{ discussion.comments.first.body }}
+"{{ discussion.comments.first.body }}"
 
-{% else %}.{% endif %}{% blocktrans with url=discussion.get_absolute_url %}Click here to reply online: {{ site.domain }}{{ url }}{% endblocktrans %}
+{% else %}.{% endif %}{% blocktrans with url=discussion.get_absolute_url %}Reply to this email to post a response, or visit this URL to reply online: {{ site.domain }}{{ url }}{% endblocktrans %}

--- a/groups/tests/test_views_discussions.py
+++ b/groups/tests/test_views_discussions.py
@@ -144,6 +144,6 @@ class TestDiscussionCreate(RequestTestCase):
         self.assertEqual(email.subject, 'New discussion in {}'.format(group.name))
         self.assertEqual(email.to, [subscriber.email])
         self.assertEqual(email.reply_to, [reply_address])
-        self.assertIn('A new discussion "{}"'.format(new_discussion.name), email.body)
+        self.assertIn('A new discussion on "{}"'.format(new_discussion.name), email.body)
         self.assertIn(subscriber.get_full_name(), email.body)
         self.assertIn(first_comment.body, email.body)


### PR DESCRIPTION
* Don't pretend the links are clickable when they aren't.
* Let the user know they can reply to the email itself.
* Add some quotes to aid readability.