### PR TITLE
Allow admin classes to be overridden through the AppConfig

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 This project uses Semantic Versioning (2.0).
 
+## Upcoming
+
+- Allow admin classes for `incuna-groups`' models to be customised easily through its
+  `AppConfig`.
+
 ## v3.1.3
 
 - Display group URLs properly in notification emails.

--- a/groups/_apps_base.py
+++ b/groups/_apps_base.py
@@ -37,11 +37,38 @@ class AdminRegisteringAppConfig(AppConfig):
     calls `admin.site.register` for each <model>:<admin> pair, *after* its normal
     setup process.  This means that admin classes registered in these AppConfigs will
     be registered after ones that are registered in `admin.py` files.
+
+    If you want your admin class paths to be individual variables, for ease of future
+    customisation, you can use update_admin_classes to implement this:
+
+    class YourAppConfig(AdminRegisteringAppConfig):
+        admin_classes = {}
+        group_admin_class_path = 'an_app.admin.OverriddenGroupAdmin'
+        user_admin_class_path = 'users.admin.MagicalUserAdmin'
+
+        def update_admin_classes(self, admin_classes):
+            super().update_admin_classes(admin_classes)
+            admin_classes.update(**{
+                'Group': self.group_admin_class_path,
+                'User': self.user_admin_class_path,
+            })
+
+    This way, if your `AppConfig` is part of a library, a project using that library
+    doesn't have to override the entirety of `admin_classes` in order to swap out
+    one entry.
     """
     admin_classes = {}
 
+    def update_admin_classes(self, admin_classes):
+        """
+        A hook method for any modifications to `admin_classes` that depend on other
+        attributes of the AppConfig (which can be overridden by subclasses).
+        """
+        pass
+
     def _register_admin_classes(self):
         """Register each <model>:<admin_class> pair in self.admin_classes."""
+        self.update_admin_classes(self.admin_classes)
         for model, admin_class in self.admin_classes.items():
             admin.site.register(
                 self.get_model(model),

--- a/groups/_apps_base.py
+++ b/groups/_apps_base.py
@@ -50,5 +50,5 @@ class AdminRegisteringAppConfig(AppConfig):
 
     def ready(self):
         """After performing normal Django setup, register our admin classes."""
-        super().ready()
+        super(AdminRegisteringAppConfig, self).ready()
         self._register_admin_classes()

--- a/groups/admin.py
+++ b/groups/admin.py
@@ -1,20 +1,10 @@
 from django.contrib import admin
 
-from .models import Discussion, Group
 
-
-@admin.register(Group)
 class GroupAdmin(admin.ModelAdmin):
     filter_horizontal = ('moderators', 'members_if_private')
     exclude = ('watchers',)
 
-    class Meta:
-        model = Group
 
-
-@admin.register(Discussion)
 class DiscussionAdmin(admin.ModelAdmin):
     exclude = ('subscribers', 'ignorers')
-
-    class Meta:
-        model = Discussion

--- a/groups/admin.py
+++ b/groups/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 
 
+# Registered in the `AppConfig`
 class GroupAdmin(admin.ModelAdmin):
     filter_horizontal = ('moderators', 'members_if_private')
     exclude = ('watchers',)
 
 
+# Also registered in the `AppConfig`
 class DiscussionAdmin(admin.ModelAdmin):
     exclude = ('subscribers', 'ignorers')

--- a/groups/apps.py
+++ b/groups/apps.py
@@ -27,7 +27,7 @@ class GroupsConfig(AdminRegisteringAppConfig):
 
     def update_admin_classes(self, admin_classes):
         super(GroupsConfig, self).update_admin_classes(admin_classes)
-        admin_classes.update(**{
+        admin_classes.update({
             'Group': self.group_admin_class_path,
             'Discussion': self.discussion_admin_class_path,
         })

--- a/groups/apps.py
+++ b/groups/apps.py
@@ -25,7 +25,9 @@ class GroupsConfig(AdminRegisteringAppConfig):
     group_admin_class_path = 'groups.admin.GroupAdmin'
     discussion_admin_class_path = 'groups.admin.DiscussionAdmin'
 
-    admin_classes = {
-        'Group': group_admin_class_path,
-        'Discussion': discussion_admin_class_path,
-    }
+    def _register_admin_classes(self):
+        self.admin_classes.update(**{
+            'Group': self.group_admin_class_path,
+            'Discussion': self.discussion_admin_class_path,
+        })
+        super(GroupsConfig, self)._register_admin_classes()

--- a/groups/apps.py
+++ b/groups/apps.py
@@ -26,7 +26,7 @@ class GroupsConfig(AdminRegisteringAppConfig):
     discussion_admin_class_path = 'groups.admin.DiscussionAdmin'
 
     def update_admin_classes(self, admin_classes):
-        super(GroupsConfig, self).update_admin_classes()
+        super(GroupsConfig, self).update_admin_classes(admin_classes)
         admin_classes.update(**{
             'Group': self.group_admin_class_path,
             'Discussion': self.discussion_admin_class_path,

--- a/groups/apps.py
+++ b/groups/apps.py
@@ -1,17 +1,31 @@
-from django.apps import AppConfig
+from ._apps_base import AdminRegisteringAppConfig
 
 
-class GroupsConfig(AppConfig):
+class GroupsConfig(AdminRegisteringAppConfig):
     """
     Configuration for `groups`.
 
     Provides:
-    * default_within_days - a default parameter for the `within_days` methods on some
+    * `default_within_days` - a default parameter for the `within_days` methods on some
       of the model managers, which return items that were posted or posted to within
       that time period.
+    * `new_comment_subject` and `new_discussion_subject` - subjects for notification
+      emails.  Each one will be formatted with the `{discussion}` a comment is on or the
+      `{group}` a discussion belongs to, respectively.
+    * `group_admin_class_path` and `discussion_admin_class_path` - these allow a project
+      to override the admin behaviour of `incuna-groups`.
     """
     name = 'groups'
+
     default_within_days = 7
 
     new_comment_subject = 'New comment on {discussion}'
     new_discussion_subject = 'New discussion in {group}'
+
+    group_admin_class_path = 'groups.admin.GroupAdmin'
+    discussion_admin_class_path = 'groups.admin.DiscussionAdmin'
+
+    admin_classes = {
+        'Group': group_admin_class_path,
+        'Discussion': discussion_admin_class_path,
+    }

--- a/groups/apps.py
+++ b/groups/apps.py
@@ -25,9 +25,9 @@ class GroupsConfig(AdminRegisteringAppConfig):
     group_admin_class_path = 'groups.admin.GroupAdmin'
     discussion_admin_class_path = 'groups.admin.DiscussionAdmin'
 
-    def _register_admin_classes(self):
-        self.admin_classes.update(**{
+    def update_admin_classes(self, admin_classes):
+        super(GroupsConfig, self).update_admin_classes()
+        admin_classes.update(**{
             'Group': self.group_admin_class_path,
             'Discussion': self.discussion_admin_class_path,
         })
-        super(GroupsConfig, self)._register_admin_classes()

--- a/groups/tests/test_apps_base.py
+++ b/groups/tests/test_apps_base.py
@@ -20,7 +20,8 @@ class TestAdminRegisteringAppConfig(TestCase):
 
     def test_register_admin_classes(self):
         """
-        Assert that admin.site.register() is called based on the value of admin_classes.
+        Assert that admin.site.register() is called based on the value of admin_classes,
+        and update_admin_classes() is also called (although it does nothing).
         """
         self.config.admin_classes = {
             'Group': 'groups.admin.GroupAdmin',
@@ -31,9 +32,11 @@ class TestAdminRegisteringAppConfig(TestCase):
         # process to get a better unit test.  Assert that it's called with the correct
         # input later on to make sure we're not cheating.
         with mock.patch.object(self.config, 'get_model', return_value=Group) as get_model:
-            with mock.patch('django.contrib.admin.site.register') as site_register:
-                self.config._register_admin_classes()
+            with mock.patch.object(self.config, 'update_admin_classes') as update_admin:
+                with mock.patch('django.contrib.admin.site.register') as site_register:
+                    self.config._register_admin_classes()
 
+        update_admin.assert_called_once_with(self.config.admin_classes)
         get_model.assert_called_once_with('Group')
         site_register.assert_called_once_with(Group, GroupAdmin)
 

--- a/groups/tests/test_apps_base.py
+++ b/groups/tests/test_apps_base.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+from django.test import TestCase
+
+import groups  # Needed for instantiating AppConfig classes.
+from groups import _apps_base
+from groups.admin import GroupAdmin
+from groups.models import Group
+
+
+class TestAdminRegisteringAppConfig(TestCase):
+    def setUp(self):
+        """
+        Create an AdminRegisteringAppConfig pointed at whichever models we have handy.
+        """
+        self.config = _apps_base.AdminRegisteringAppConfig('groups', groups)
+
+    def test_register_admin_classes(self):
+        """
+        Assert that admin.site.register() is called based on the value of admin_classes.
+        """
+        self.config.admin_classes = {
+            'Group': 'groups.admin.GroupAdmin',
+        }
+
+        # Mock out get_model() because otherwise the AppConfig will try to check if it's
+        # prepared the models already, which it hasn't since we're shortcutting the
+        # process to get a better unit test.  Assert that it's called with the correct
+        # input later on to make sure we're not cheating.
+        with mock.patch.object(self.config, 'get_model', return_value=Group) as get_model:
+            with mock.patch('django.contrib.admin.site.register') as site_register:
+                self.config._register_admin_classes()
+
+        get_model.assert_called_once_with('Group')
+        site_register.assert_called_once_with(Group, GroupAdmin)
+
+    def test_ready(self):
+        """
+        Assert that ready() calls _register_admin_classes() and the superclass's ready().
+        """
+        with mock.patch('django.apps.config.AppConfig.ready') as super_ready:
+            with mock.patch.object(self.config, '_register_admin_classes') as register:
+                self.config.ready()
+
+        super_ready.assert_called_once_with()
+        register.assert_called_once_with()

--- a/groups/tests/test_apps_base.py
+++ b/groups/tests/test_apps_base.py
@@ -1,4 +1,7 @@
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from django.test import TestCase
 


### PR DESCRIPTION
Registering admin classes is hard.  Registering admin classes that you've overridden from some existing ones is even harder.  So that `GroupAdmin` and `DiscussionAdmin` can be overridden in other projects, I've added some special sauce to the `AppConfig` that allows us to slot in new admin classes from there.  (Many thanks to @Ian-Foote and @meshy for the help!)

The `AppConfig` now inherits from a new base class, `AdminRegisteringAppConfig`, which I'd like to see spun off into a separate library some time soon, since this looks like we could use it in all sorts of places.  This base class has an attribute called `admin_classes`, which is a dictionary of `{<model_name>: <admin_class_path>}`, and just after running its normal `ready()` process, registers all the admin classes defined in that dictionary.

@incuna/backend review please?