### PR TITLE
Allow users to upload files as attachments to text comments

### DIFF
--- a/groups/forms.py
+++ b/groups/forms.py
@@ -57,6 +57,12 @@ class AddFileComment(BaseAddCommentForm):
 class AddTextCommentWithAttachment(BaseAddCommentForm):
     file = forms.FileField()
 
+    def __init__(self, *args, **kwargs):
+        """Add nicer field labels."""
+        super(AddTextCommentWithAttachment, self).__init__(*args, **kwargs)
+        self.fields['body'].label = 'Comment'
+        self.fields['file'].label = 'Attachment'
+
     def build_helper(self):
         helper = super(AddTextCommentWithAttachment, self).build_helper()
         helper.layout = Layout(

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -54,6 +54,25 @@ class AddFileComment(BaseAddCommentForm):
         model = models.FileComment
 
 
+class AddTextCommentWithAttachment(BaseAddCommentForm):
+    file = forms.FileField()
+
+    def build_helper(self):
+        helper = super(AddTextCommentWithAttachment, self).build_helper()
+        helper.layout = Layout(
+            'body',
+            'file',
+            FormActions(
+                StrictButton('Upload and post', type='submit'),
+            ),
+        )
+        return helper
+
+    class Meta:
+        fields = ('body', 'file',)
+        model = models.TextComment
+
+
 class DiscussionCreate(forms.Form):
     comment = forms.CharField(widget=forms.Textarea)
     name = forms.CharField(max_length=255)

--- a/groups/tests/test_forms.py
+++ b/groups/tests/test_forms.py
@@ -88,6 +88,42 @@ class TestAddFileComment(Python2AssertMixin, RequestTestCase):
         self.assertEqual(button.get('type'), 'submit')
 
 
+class TestAddTextCommentWithAttachment(Python2AssertMixin, RequestTestCase):
+    form = forms.AddTextCommentWithAttachment
+    model = models.TextComment
+
+    def test_form_fields(self):
+        expected = ['body', 'file']
+        fields = self.form.base_fields.keys()
+        self.assertCountEqual(fields, expected)
+
+    def test_form_valid(self):
+        data = {'body': 'I am a comment'}
+        file_data = {'file': uploadable_file()}
+        form = self.form(data=data, files=file_data)
+        self.assertTrue(form.is_valid(), msg=form.errors)
+
+    def test_form_not_valid(self):
+        form = self.form(data={})
+        self.assertFalse(form.is_valid())
+        self.assertIn('body', form.errors)
+        self.assertIn('file', form.errors)
+
+    def test_submit_not_input(self):
+        """The form does not have a submit <input>."""
+        form = self.form()
+        self.assertFalse(has_submit(form))
+
+    def test_submit_button(self):
+        """
+        The form has a submit <button>.
+
+        This allows for more flexibility in styling.
+        """
+        button = get_button(self.form())
+        self.assertEqual(button.get('type'), 'submit')
+
+
 class TestDiscussionCreateForm(Python2AssertMixin, RequestTestCase):
     form = forms.DiscussionCreate
 

--- a/groups/tests/test_urls.py
+++ b/groups/tests/test_urls.py
@@ -61,6 +61,14 @@ class TestGroupUrls(URLTestCase):
             url_kwargs={'pk': self.pk}
         )
 
+    def test_comment_post_with_attachment(self):
+        self.assert_url_matches_view(
+            comments.CommentPostWithAttachment,
+            '/groups/discussions/{}/post-with-attachment/'.format(self.pk),
+            'comment-post-with-attachment',
+            url_kwargs={'pk': self.pk}
+        )
+
     def test_comment_delete(self):
         self.assert_url_matches_view(
             comments.CommentDelete,

--- a/groups/urls.py
+++ b/groups/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
             name='comment-upload-file',
         ),
         url(
+            r'^post-with-attachment/$',
+            comments.CommentPostWithAttachment.as_view(),
+            name='comment-post-with-attachment',
+        ),
+        url(
             r'^subscribe/$',
             subscriptions.DiscussionSubscribe.as_view(),
             name='discussion-subscribe',

--- a/groups/views/comments.py
+++ b/groups/views/comments.py
@@ -24,6 +24,21 @@ class CommentUploadFile(CommentPostView):
     template_name = 'groups/comment_upload_file.html'
 
 
+class CommentPostWithAttachment(CommentPostView):
+    """Posts a text comment with an attached file to a particular discussion."""
+    form_class = forms.AddTextCommentWithAttachment
+    template_name = 'groups/comment_upload_file.html'
+
+    def form_valid(self, form):
+        response = super(CommentPostWithAttachment, self).form_valid(form)
+        models.AttachedFile.objects.create(
+            file=form.file,
+            user=self.object.user,
+            comment=self.object,
+        )
+        return response
+
+
 class CommentDelete(DeleteView):
     """
     Deletes a particular comment after confirming with an 'Are you sure?' page.

--- a/groups/views/comments.py
+++ b/groups/views/comments.py
@@ -32,9 +32,9 @@ class CommentPostWithAttachment(CommentPostView):
     def form_valid(self, form):
         response = super(CommentPostWithAttachment, self).form_valid(form)
         models.AttachedFile.objects.create(
-            file=form.file,
+            file=form.cleaned_data['file'],
             user=self.object.user,
-            comment=self.object,
+            attached_to=self.object,
         )
         return response
 


### PR DESCRIPTION
@incuna/backend More comment attachment stuff.

This PR only adds the new form/view/URL and doesn't displace any of the existing functionality.

As with my other PRs from this week, I'll merge it once Travis is happy with it and I've checked it over; feel free to make comments after the fact.