### PR TITLE
Use the new "post with attachment" file upload.

### DIFF
--- a/groups/templates/groups/discussion_thread_base.html
+++ b/groups/templates/groups/discussion_thread_base.html
@@ -28,5 +28,5 @@
 
     {% crispy form %}
 
-    <p><a href="{% url 'comment-upload-file' pk=discussion.pk %}">Upload a file to this discussion</a></p>
+    <p><a href="{% url 'comment-post-with-attachment' pk=discussion.pk %}">Upload a file to this discussion</a></p>
 {% endblock groups_main_content %}


### PR DESCRIPTION
@incuna/backend I thought I'd do this separately, although it looks like it's a one-line PR after all.

I haven't removed anything yet.  The `FileComment` functionality continues to exist for now.  Do you think we should get rid of it and allow the "text comment with attachment" to supersede it entirely, or keep it around in case it's needed elsewhere?