### PR TITLE
Order groups and discussions in a more user-friendly way

### DIFF
--- a/groups/managers.py
+++ b/groups/managers.py
@@ -83,6 +83,9 @@ class DiscussionQuerySet(WithinDaysQuerySetMixin, models.QuerySet):
         User = get_user_model()
         return User.objects.filter(comments__discussion__in=self).distinct()
 
+    def with_last_updated(self):
+        return self.annotate(last_updated=models.Max('comments__date_created'))
+
 
 class CommentManagerMixin(WithinDaysQuerySetMixin):
     """

--- a/groups/models.py
+++ b/groups/models.py
@@ -98,9 +98,6 @@ class Discussion(models.Model):
     def get_latest_comment(self):
         return self.comments.latest('date_created')
 
-    def get_date_updated(self):
-        return self.get_latest_comment().date_created
-
     def get_total_replies(self):
         return self.comments.count()
 

--- a/groups/models.py
+++ b/groups/models.py
@@ -98,6 +98,9 @@ class Discussion(models.Model):
     def get_latest_comment(self):
         return self.comments.latest('date_created')
 
+    def get_date_updated(self):
+        return self.get_latest_comment().date_created
+
     def get_total_replies(self):
         return self.comments.count()
 

--- a/groups/templates/groups/group_list_base.html
+++ b/groups/templates/groups/group_list_base.html
@@ -19,6 +19,4 @@
             </tr>
         {% endfor %}
     </table>
-
-    {% include "includes/_pagination.html" %}
 {% endblock groups_main_content %}

--- a/groups/tests/test_groups_functional.py
+++ b/groups/tests/test_groups_functional.py
@@ -24,6 +24,7 @@ class TestGroupDetail(RenderedContentTestCase):
     def test_detail_display(self):
         group = factories.GroupFactory.create()
         discussion = factories.DiscussionFactory.create(group=group)
+        factories.TextCommentFactory.create(discussion=discussion)
         expected_content = {
             group.name: True,
             discussion.name: True,

--- a/groups/tests/test_managers.py
+++ b/groups/tests/test_managers.py
@@ -164,6 +164,20 @@ class TestDiscussionManager(Python2AssertMixin, TestCase):
 
         self.assertCountEqual([discussion], models.Discussion.objects.within_time(delta))
 
+    def test_with_last_updated(self):
+        discussion = factories.DiscussionFactory.create()
+        latest = factories.TextCommentFactory.create(
+            discussion=discussion,
+            date_created=datetime.datetime(2970, 1, 1)
+        )
+        factories.TextCommentFactory.create(
+            discussion=discussion,
+            date_created=datetime.datetime(1970, 1, 1)
+        )
+
+        last_updated = models.Discussion.objects.with_last_updated()
+        self.assertEqual(last_updated.get().last_updated, latest.date_created)
+
 
 class TestCommentManager(Python2AssertMixin, TestCase):
     def test_for_group(self):

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -126,17 +126,6 @@ class TestDiscussion(Python2AssertMixin, TestCase):
 
         self.assertEqual(discussion.get_latest_comment(), latest)
 
-    def test_get_date_updated(self):
-        """This method returns the creation date of the most recent comment."""
-        discussion = factories.DiscussionFactory.create()
-        latest = factories.BaseCommentFactory.create(discussion=discussion)
-        factories.BaseCommentFactory.create(
-            discussion=discussion,
-            date_created=datetime.datetime(1970, 1, 1),
-        )
-
-        self.assertEqual(discussion.get_date_updated(), latest.date_created)
-
 
 class TestBaseComment(Python2AssertMixin, TestCase):
     def test_fields(self):

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.core import signing
 from django.test import TestCase
 from incuna_test_utils.compat import Python2AssertMixin
@@ -112,6 +114,28 @@ class TestDiscussion(Python2AssertMixin, TestCase):
 
         signed_data = discussion.generate_reply_uuid(user)
         self.assertEqual(signing.loads(signed_data), expected_data)
+
+    def test_get_latest_comment(self):
+        """This method returns the most recent comment."""
+        discussion = factories.DiscussionFactory.create()
+        latest = factories.BaseCommentFactory.create(discussion=discussion)
+        factories.BaseCommentFactory.create(
+            discussion=discussion,
+            date_created=datetime.datetime(1970, 1, 1),
+        )
+
+        self.assertEqual(discussion.get_latest_comment(), latest)
+
+    def test_get_date_updated(self):
+        """This method returns the creation date of the most recent comment."""
+        discussion = factories.DiscussionFactory.create()
+        latest = factories.BaseCommentFactory.create(discussion=discussion)
+        factories.BaseCommentFactory.create(
+            discussion=discussion,
+            date_created=datetime.datetime(1970, 1, 1),
+        )
+
+        self.assertEqual(discussion.get_date_updated(), latest.date_created)
 
 
 class TestBaseComment(Python2AssertMixin, TestCase):

--- a/groups/tests/test_views_groups.py
+++ b/groups/tests/test_views_groups.py
@@ -9,7 +9,8 @@ class TestGroupList(Python2AssertMixin, RequestTestCase):
     view_class = groups.GroupList
 
     def test_get(self):
-        groups = factories.GroupFactory.create_batch(2)
+        group_last = factories.GroupFactory.create(name='zzzz')
+        group_first = factories.GroupFactory.create(name='aaaa')
 
         request = self.create_request()
         view = self.view_class.as_view()
@@ -17,7 +18,7 @@ class TestGroupList(Python2AssertMixin, RequestTestCase):
         response = view(request)
         self.assertEqual(response.status_code, 200)
         object_list = response.context_data['object_list']
-        self.assertCountEqual(groups, object_list)
+        self.assertCountEqual(object_list, [group_first, group_last])
 
 
 class TestGroupDetail(RequestTestCase):

--- a/groups/views/groups.py
+++ b/groups/views/groups.py
@@ -7,8 +7,8 @@ from .. import forms, models
 class GroupList(ListView):
     """Show a top-level list of discussion groups."""
     model = models.Group
-    paginate_by = 5
     template_name = 'groups/group_list.html'
+    ordering = 'name'
 
 
 class GroupDetail(ListView):

--- a/groups/views/groups.py
+++ b/groups/views/groups.py
@@ -1,3 +1,5 @@
+from operator import methodcaller
+
 from django.shortcuts import get_object_or_404
 from django.views.generic import ListView
 
@@ -27,8 +29,19 @@ class GroupDetail(ListView):
         """Return all discussions on the particular group we're using."""
         return super(GroupDetail, self).get_queryset().filter(group=self.group)
 
+    def sort_object_list(self, object_list):
+        """
+        Order the list of discussions by time of most recent update.
+
+        Since this sorting irreversibly turns a queryset into a list, it's been separated
+        from get_queryset() to allow for extensibility on the latter.
+        """
+        return sorted(object_list, key=methodcaller('get_date_updated'), reverse=True)
+
     def get_context_data(self, *args, **kwargs):
+        """Sort the object list and allow the group to be displayed properly."""
         context = super(GroupDetail, self).get_context_data(*args, **kwargs)
+        context['object_list'] = self.sort_object_list(context['object_list'])
         context['group'] = self.group
         context['group-subscribe-form'] = self.subscribe_form_class(
             user=self.request.user,

--- a/groups/views/groups.py
+++ b/groups/views/groups.py
@@ -16,7 +16,7 @@ class GroupList(ListView):
 class GroupDetail(ListView):
     """Show the discussions belonging to a group."""
     model = models.Discussion
-    paginate_by = 5
+    paginate_by = 10
     template_name = 'groups/group_detail.html'
     subscribe_form_class = forms.SubscribeForm
 

--- a/groups/views/groups.py
+++ b/groups/views/groups.py
@@ -18,7 +18,13 @@ class GroupDetail(ListView):
     template_name = 'groups/group_detail.html'
     subscribe_form_class = forms.SubscribeForm
 
+    def dispatch(self, request, *args, **kwargs):
+        """Get the group object we're accessing according to the pk in the URL."""
+        self.group = get_object_or_404(models.Group, pk=self.kwargs['pk'])
+        return super(GroupDetail, self).dispatch(request, *args, **kwargs)
+
     def get_queryset(self):
+        """Return all discussions on the particular group we're using."""
         return super(GroupDetail, self).get_queryset().filter(group=self.group)
 
     def get_context_data(self, *args, **kwargs):
@@ -30,7 +36,3 @@ class GroupDetail(ListView):
             url_name='group-subscribe',
         )
         return context
-
-    def dispatch(self, request, *args, **kwargs):
-        self.group = get_object_or_404(models.Group, pk=self.kwargs['pk'])
-        return super(GroupDetail, self).dispatch(request, *args, **kwargs)


### PR DESCRIPTION
@incuna/backend I was looking at a site using `incuna-groups` and I realised the existing ordering of groups and discussions is quite unhelpful, so I've changed it.

I think groups shouldn't be paginated and should instead be displayed in their entirety in alphabetical order.  There's a potential expansion where groups are put into sections like you'd see on an existing forum, but that's quite complex and we don't need it any time yet.  As it is, I don't think groups should ever disappear from the list unless explicitly removed, so we shouldn't paginate or force users to hunt for the group(s) they might be interested in.

Discussions need to be displayed in order of how recently they were updated.  The most currently active threads should be at the top of the list and it goes down from there.  I think five might also be quite small a pagination limit - 10 or even 20 might be better.