### PR TITLE
Get rid of the now-obsolete FileComment

### DIFF
--- a/groups/forms.py
+++ b/groups/forms.py
@@ -37,23 +37,6 @@ class AddTextComment(BaseAddCommentForm):
         model = models.TextComment
 
 
-class AddFileComment(BaseAddCommentForm):
-    """A form that uploads FileComments."""
-    def build_helper(self):
-        helper = super(AddFileComment, self).build_helper()
-        helper.layout = Layout(
-            'file',
-            FormActions(
-                StrictButton('Upload this file', type='submit'),
-            ),
-        )
-        return helper
-
-    class Meta:
-        fields = ('file',)
-        model = models.FileComment
-
-
 class AddTextCommentWithAttachment(BaseAddCommentForm):
     file = forms.FileField()
 

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -40,12 +40,6 @@ class AddTextComment(BaseAddCommentForm):
 class AddTextCommentWithAttachment(BaseAddCommentForm):
     file = forms.FileField()
 
-    def __init__(self, *args, **kwargs):
-        """Add nicer field labels."""
-        super(AddTextCommentWithAttachment, self).__init__(*args, **kwargs)
-        self.fields['body'].label = 'Comment'
-        self.fields['file'].label = 'Attachment'
-
     def build_helper(self):
         helper = super(AddTextCommentWithAttachment, self).build_helper()
         helper.layout = Layout(
@@ -58,8 +52,12 @@ class AddTextCommentWithAttachment(BaseAddCommentForm):
         return helper
 
     class Meta:
-        fields = ('body', 'file',)
         model = models.TextComment
+        fields = ('body', 'file',)
+        labels = {
+            'body': 'Comment',
+            'file': 'Attachment',
+        }
 
 
 class DiscussionCreate(forms.Form):

--- a/groups/models.py
+++ b/groups/models.py
@@ -204,16 +204,6 @@ class TextComment(BaseComment):
     template_name = 'groups/text_comment.html'
 
 
-class FileComment(BaseComment):
-    """A comment with an uploaded file. No text."""
-    file = models.FileField(upload_to='groups/attachments')
-    template_name = 'groups/file_comment.html'
-
-    def short_filename(self):
-        """Display only the name of the file, sans its path within client_media."""
-        return os.path.basename(self.file.name)
-
-
 class AttachedFile(models.Model):
     """A file upload that can be attached to a comment."""
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='attachments')

--- a/groups/templates/groups/comment_post_with_attachment.html
+++ b/groups/templates/groups/comment_post_with_attachment.html
@@ -1,0 +1,1 @@
+{% extends "groups/comment_post_with_attachment_base.html" %}

--- a/groups/templates/groups/comment_post_with_attachment_base.html
+++ b/groups/templates/groups/comment_post_with_attachment_base.html
@@ -2,10 +2,10 @@
 
 {% load crispy_forms_tags %}
 
-{% block groups_title %}Upload a file to {{ discussion.name }}{% endblock groups_title %}
+{% block groups_title %}Post to {{ discussion.name }}{% endblock groups_title %}
 
 {% block groups_subtitle %}
-    <h2>Upload a file to {{ discussion.name }}</h2>
+    <h2>Post to {{ discussion.name }}</h2>
 {% endblock groups_subtitle %}
 
 {% block back_link %}

--- a/groups/templates/groups/comment_upload_file.html
+++ b/groups/templates/groups/comment_upload_file.html
@@ -1,1 +1,0 @@
-{% extends "groups/comment_upload_file_base.html" %}

--- a/groups/tests/factories.py
+++ b/groups/tests/factories.py
@@ -60,13 +60,6 @@ class TextCommentFactory(BaseCommentFactory):
         model = models.TextComment
 
 
-class FileCommentFactory(BaseCommentFactory):
-    file = images.LocalFileField()
-
-    class Meta:
-        model = models.FileComment
-
-
 class AttachedFileFactory(factory.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
     file = images.LocalFileField()

--- a/groups/tests/test_forms.py
+++ b/groups/tests/test_forms.py
@@ -54,40 +54,6 @@ class TestAddTextComment(Python2AssertMixin, RequestTestCase):
         self.assertEqual(button.get('type'), 'submit')
 
 
-class TestAddFileComment(Python2AssertMixin, RequestTestCase):
-    form = forms.AddFileComment
-    model = models.FileComment
-
-    def test_form_fields(self):
-        expected = ['file']
-        fields = self.form.base_fields.keys()
-        self.assertCountEqual(fields, expected)
-
-    def test_form_valid(self):
-        file_data = {'file': uploadable_file()}
-        form = self.form(files=file_data)
-        self.assertTrue(form.is_valid(), msg=form.errors)
-
-    def test_form_not_valid(self):
-        form = self.form(data={})
-        self.assertFalse(form.is_valid())
-        self.assertIn('file', form.errors)
-
-    def test_submit_not_input(self):
-        """The form does not have a submit <input>."""
-        form = self.form()
-        self.assertFalse(has_submit(form))
-
-    def test_submit_button(self):
-        """
-        The form has a submit <button>.
-
-        This allows for more flexibility in styling.
-        """
-        button = get_button(self.form())
-        self.assertEqual(button.get('type'), 'submit')
-
-
 class TestAddTextCommentWithAttachment(Python2AssertMixin, RequestTestCase):
     form = forms.AddTextCommentWithAttachment
     model = models.TextComment

--- a/groups/tests/test_groups_functional.py
+++ b/groups/tests/test_groups_functional.py
@@ -36,32 +36,17 @@ class TestGroupDetail(RenderedContentTestCase):
 class TestDiscussionThread(RenderedContentTestCase):
     view = discussions.DiscussionThread
 
-    def test_text_comment_display(self):
+    def test_thread_display(self):
         comment_body = 'I am a comment and proud of it!'
-        comment = factories.TextCommentFactory.create(
-            body=comment_body,
-        )
+        comment = factories.TextCommentFactory.create(body=comment_body)
+        attachment = factories.AttachedFileFactory.create(attached_to=comment)
         discussion = comment.discussion
 
         expected_content = {
             discussion.name: True,
             comment_body: True,
-            str(comment.user): True,
-            reverse('discussion-subscribe', kwargs={'pk': discussion.pk}): True,
-            'Post comment': True,  # The label on the 'add comment' button
-            'type="submit"': True,  # The button itself
-        }
-
-        self.render_view_and_assert_content(expected_content, pk=discussion.pk)
-
-    def test_file_comment_display(self):
-        comment = factories.FileCommentFactory.create()
-        discussion = comment.discussion
-
-        expected_content = {
-            discussion.name: True,
-            comment.file.url: True,
-            comment.file.name: True,
+            attachment.file.url: True,
+            attachment.file.name: True,
             str(comment.user): True,
             reverse('discussion-subscribe', kwargs={'pk': discussion.pk}): True,
             'Post comment': True,  # The label on the 'add comment' button

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -130,7 +130,6 @@ class TestBaseComment(Python2AssertMixin, TestCase):
             'polymorphic_ctype',
             'polymorphic_ctype_id',
             'textcomment',
-            'filecomment',
         ]
         self.assertCountEqual(fields, expected)
 
@@ -211,33 +210,6 @@ class TestTextComment(Python2AssertMixin, TestCase):
             'basecomment_ptr_id',
         ]
         self.assertCountEqual(fields, expected)
-
-
-class TestFileComment(Python2AssertMixin, TestCase):
-    def test_fields(self):
-        fields = models.FileComment._meta.get_all_field_names()
-        expected = [
-            'id',
-            'file',
-            'discussion',
-            'discussion_id',
-            'user',
-            'user_id',
-            'date_created',
-            'state',
-            'attachments',
-
-            'polymorphic_ctype',
-            'polymorphic_ctype_id',
-            'basecomment_ptr',
-            'basecomment_ptr_id',
-        ]
-        self.assertCountEqual(fields, expected)
-
-    def test_short_filename(self):
-        filename = '/groups/file_comments/test_file_comment.txt'
-        comment = factories.FileCommentFactory.create(file__filename=filename)
-        self.assertEqual(comment.short_filename(), 'test_file_comment.txt')
 
 
 class TestAttachedFile(Python2AssertMixin, TestCase):

--- a/groups/tests/test_urls.py
+++ b/groups/tests/test_urls.py
@@ -53,14 +53,6 @@ class TestGroupUrls(URLTestCase):
             url_kwargs={'pk': self.pk}
         )
 
-    def test_comment_upload_file(self):
-        self.assert_url_matches_view(
-            comments.CommentUploadFile,
-            '/groups/discussions/{}/upload-file/'.format(self.pk),
-            'comment-upload-file',
-            url_kwargs={'pk': self.pk}
-        )
-
     def test_comment_post_with_attachment(self):
         self.assert_url_matches_view(
             comments.CommentPostWithAttachment,

--- a/groups/tests/test_views_comments.py
+++ b/groups/tests/test_views_comments.py
@@ -17,37 +17,6 @@ from .. import models
 from ..views import comments
 
 
-class TestCommentUploadFile(Python2AssertMixin, RequestTestCase):
-    view_class = comments.CommentUploadFile
-
-    def make_datetime(self, year, month, day):
-        return datetime.datetime(year, month, day, tzinfo=pytz.utc)
-
-    def test_get(self):
-        discussion = factories.DiscussionFactory.create()
-        request = self.create_request()
-        view = self.view_class.as_view()
-
-        response = view(request, pk=discussion.pk)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context_data['discussion'], discussion)
-
-    def test_post(self):
-        discussion = factories.DiscussionFactory.create()
-        file = factories.FileCommentFactory.build().file.file
-        data = {'file': file}
-
-        # Hit the view, passing in the necessaries.
-        request = self.create_request('post', data=data)
-        view = self.view_class.as_view()
-        view(request, pk=discussion.pk)
-
-        # Assert that one comment was created with the appropriate properties.
-        created_comment = models.FileComment.objects.get(discussion=discussion)
-        self.assertEqual(created_comment.discussion, discussion)
-        self.assertEqual(created_comment.user, request.user)
-
-
 class TestCommentPostWithAttachment(Python2AssertMixin, RequestTestCase):
     view_class = comments.CommentPostWithAttachment
 
@@ -65,7 +34,7 @@ class TestCommentPostWithAttachment(Python2AssertMixin, RequestTestCase):
 
     def test_post(self):
         discussion = factories.DiscussionFactory.create()
-        uploadable_file = factories.FileCommentFactory.build().file.file
+        uploadable_file = factories.AttachedFileFactory.build().file.file
         body = 'I am a comment'
         data = {'body': body, 'file': uploadable_file}
 

--- a/groups/urls.py
+++ b/groups/urls.py
@@ -29,11 +29,6 @@ urlpatterns = [
             name='discussion-thread',
         ),
         url(
-            r'^upload-file/$',
-            comments.CommentUploadFile.as_view(),
-            name='comment-upload-file',
-        ),
-        url(
             r'^post-with-attachment/$',
             comments.CommentPostWithAttachment.as_view(),
             name='comment-post-with-attachment',

--- a/groups/views/comments.py
+++ b/groups/views/comments.py
@@ -18,16 +18,10 @@ from .. import forms, models
 NEW_COMMENT_SUBJECT = apps.get_app_config('groups').new_comment_subject
 
 
-class CommentUploadFile(CommentPostView):
-    """Posts a file to a particular discussion."""
-    form_class = forms.AddFileComment
-    template_name = 'groups/comment_upload_file.html'
-
-
 class CommentPostWithAttachment(CommentPostView):
     """Posts a text comment with an attached file to a particular discussion."""
     form_class = forms.AddTextCommentWithAttachment
-    template_name = 'groups/comment_upload_file.html'
+    template_name = 'groups/comment_post_with_attachment.html'
 
     def form_valid(self, form):
         response = super(CommentPostWithAttachment, self).form_valid(form)


### PR DESCRIPTION
@incuna/backend 'tis GONE.  The ability to add attachments to other comments (usually `TextComment`s but there's room for everything) obviates the need for `FileComment` pretty handily.